### PR TITLE
feat: shorter docs URLs

### DIFF
--- a/apps/svelte.dev/src/routes/content.json/+server.ts
+++ b/apps/svelte.dev/src/routes/content.json/+server.ts
@@ -18,11 +18,7 @@ function get_href(parts: string[]) {
 async function content() {
 	const blocks: Block[] = [];
 	const breadcrumbs: string[] = [];
-	// We want the actual contents: docs -> docs/svelte etc -> docs/svelte/overview etc -> docs/svelte/overview/introduction etc
-	let docs = Object.values(_docs).flatMap((topic) =>
-		topic.children.flatMap((section) => section.children)
-	);
-	docs = docs.concat(
+	const docs = Object.values(_docs.pages).concat(
 		index.tutorial.children.flatMap((topic) =>
 			topic.children.flatMap((section) =>
 				section.children.map((entry) => ({

--- a/apps/svelte.dev/src/routes/docs/[...path]/+layout.server.ts
+++ b/apps/svelte.dev/src/routes/docs/[...path]/+layout.server.ts
@@ -4,7 +4,7 @@ import { error } from '@sveltejs/kit';
 export const prerender = true;
 
 export async function load({ params }) {
-	const page = docs[`docs/${params.path.split('/')[0]}`];
+	const page = docs.topics[params.path.split('/')[0]];
 
 	if (!page) {
 		error(404, 'Not found');

--- a/apps/svelte.dev/src/routes/docs/[...path]/+page.server.js
+++ b/apps/svelte.dev/src/routes/docs/[...path]/+page.server.js
@@ -3,34 +3,20 @@ import { render_content } from '$lib/server/renderer';
 import { error, redirect } from '@sveltejs/kit';
 
 export async function load({ params }) {
-	const document = docs[`docs/${params.path}`];
+	const document = docs.pages[params.path];
 
 	if (!document) {
+		const topic = docs.topics[params.path];
+		if (topic) {
+			redirect(307, `/${topic.children[0].children[0].slug}`);
+		}
 		error(404);
 	}
-
-	if (!document.body) {
-		let child = document;
-
-		while (child.children[0]) {
-			child = child.children[0];
-		}
-
-		if (child === document) {
-			error(404);
-		}
-
-		redirect(307, `/${child.slug}`);
-	}
-
-	const pkg = params.path.split('/')[0];
 
 	return {
 		document: {
 			...document,
-			body: await render_content(document.file, document.body),
-			prev: document.prev?.slug.startsWith(`docs/${pkg}/`) ? document.prev : null,
-			next: document.next?.slug.startsWith(`docs/${pkg}/`) ? document.next : null
+			body: await render_content(document.file, document.body)
 		}
 	};
 }

--- a/apps/svelte.dev/src/routes/nav.json/+server.ts
+++ b/apps/svelte.dev/src/routes/nav.json/+server.ts
@@ -9,18 +9,16 @@ export const GET = async () => {
 };
 
 async function get_nav_list(): Promise<NavigationLink[]> {
-	const docs = Object.values(_docs)
-		.filter((entry) => entry.slug.split('/').length === 2)
-		.map((topic) => ({
-			title: topic.metadata.title,
-			sections: topic.children.map((section) => ({
-				title: section.metadata.title,
-				sections: section.children.map((page) => ({
-					title: page.metadata.title,
-					path: '/' + page.slug
-				}))
+	const docs = Object.values(_docs.topics).map((topic) => ({
+		title: topic.metadata.title,
+		sections: topic.children.map((section) => ({
+			title: section.metadata.title,
+			sections: section.children.map((page) => ({
+				title: page.metadata.title,
+				path: '/' + page.slug
 			}))
-		}));
+		}))
+	}));
 
 	const blog = [
 		{


### PR DESCRIPTION
Removes the section part from the slugs.

This is a bit more code and duplication than I'd like, but the alternative would be to mess with the logic inside `site-kit/src/lib/server/content/index.ts` and special-case docs, which felt too hacky. _Update:_ I adjusted the structure to fit the use cases better, which justifies this approach further.
This approach is also more future proof if we decide to adjust the structure more to our liking.

Fixes #62