### PR TITLE
feat: add MODULE replacement syntax, consolidate sync

### DIFF
--- a/apps/svelte.dev/content/docs/kit/20-core-concepts/20-load.md
+++ b/apps/svelte.dev/content/docs/kit/20-core-concepts/20-load.md
@@ -664,6 +664,7 @@ To summarize, a `load` function will rerun in the following situations:
 - It references a property of `url` (such as `url.pathname` or `url.search`) whose value has changed. Properties in `request.url` are _not_ tracked
 - It calls `url.searchParams.get(...)`, `url.searchParams.getAll(...)` or `url.searchParams.has(...)` and the parameter in question changes. Accessing other properties of `url.searchParams` will have the same effect as accessing `url.search`.
 - It calls `await parent()` and a parent `load` function reran
+- A child `load` function calls `await parent()` and is rerunning, and the parent is a server load function
 - It declared a dependency on a specific URL via [`fetch`](#making-fetch-requests) (universal load only) or [`depends`](types#public-types-loadevent), and that URL was marked invalid with [`invalidate(url)`](modules#$app-navigation-invalidate)
 - All active `load` functions were forcibly rerun with [`invalidateAll()`](modules#$app-navigation-invalidateall)
 

--- a/apps/svelte.dev/content/docs/kit/98-reference/10-@sveltejs-kit.md
+++ b/apps/svelte.dev/content/docs/kit/98-reference/10-@sveltejs-kit.md
@@ -814,6 +814,10 @@ Compress files in `directory` with gzip and brotli, where appropriate. Generates
 </div>
 </div>
 
+## Config
+
+See the [configuration reference](/docs/kit/configuration) for details.
+
 ## Cookies
 
 <div class="ts-block">
@@ -1084,6 +1088,10 @@ The content of the error.
 </div>
 </div>
 </div>
+
+## KitConfig
+
+See the [configuration reference](/docs/kit/configuration) for details.
 
 ## LessThan
 

--- a/apps/svelte.dev/content/docs/svelte/04-runtime/03-lifecycle-hooks.md
+++ b/apps/svelte.dev/content/docs/svelte/04-runtime/03-lifecycle-hooks.md
@@ -45,7 +45,13 @@ If a function is returned from `onMount`, it will be called when the component i
 
 ## `onDestroy`
 
-> EXPORT_SNIPPET: svelte#onDestroy
+<div class="ts-block">
+
+```dts
+function onDestroy(fn: () => any): void;
+```
+
+</div>
 
 Schedules a callback to run immediately before the component is unmounted.
 

--- a/apps/svelte.dev/content/docs/svelte/98-reference/21-svelte-store.md
+++ b/apps/svelte.dev/content/docs/svelte/98-reference/21-svelte-store.md
@@ -186,4 +186,140 @@ function writable<T>(
 
 </div>
 
+## Readable
+
+Readable interface for subscribing.
+
+<div class="ts-block">
+
+```dts
+interface Readable<T> {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+subscribe(this: void, run: Subscriber<T>, invalidate?: () => void): Unsubscriber;
+```
+
+<div class="ts-block-property-details">
+
+<div class="ts-block-property-bullets">
+
+- `run` subscription callback
+- `invalidate` cleanup callback
+
+</div>
+
+Subscribe on value changes.
+
+</div>
+</div>
+</div>
+
+## StartStopNotifier
+
+Start and stop notification callbacks.
+This function is called when the first subscriber subscribes.
+
+<div class="ts-block">
+
+```dts
+type StartStopNotifier<T> = (
+	set: (value: T) => void,
+	update: (fn: Updater<T>) => void
+) => void | (() => void);
+```
+
+
+</div>
+
+## Subscriber
+
+Callback to inform of a value updates.
+
+<div class="ts-block">
+
+```dts
+type Subscriber<T> = (value: T) => void;
+```
+
+
+</div>
+
+## Unsubscriber
+
+Unsubscribes from value updates.
+
+<div class="ts-block">
+
+```dts
+type Unsubscriber = () => void;
+```
+
+
+</div>
+
+## Updater
+
+Callback to update a value.
+
+<div class="ts-block">
+
+```dts
+type Updater<T> = (value: T) => T;
+```
+
+
+</div>
+
+## Writable
+
+Writable interface for both updating and subscribing.
+
+<div class="ts-block">
+
+```dts
+interface Writable<T> extends Readable<T> {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+set(this: void, value: T): void;
+```
+
+<div class="ts-block-property-details">
+
+<div class="ts-block-property-bullets">
+
+- `value` to set
+
+</div>
+
+Set value and inform subscribers.
+
+</div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+update(this: void, updater: Updater<T>): void;
+```
+
+<div class="ts-block-property-details">
+
+<div class="ts-block-property-bullets">
+
+- `updater` callback
+
+</div>
+
+Update value using callback and inform subscribers.
+
+</div>
+</div>
+</div>
+
 

--- a/apps/svelte.dev/content/docs/svelte/98-reference/21-svelte-transition.md
+++ b/apps/svelte.dev/content/docs/svelte/98-reference/21-svelte-transition.md
@@ -193,4 +193,402 @@ function slide(
 
 </div>
 
+## BlurParams
+
+<div class="ts-block">
+
+```dts
+interface BlurParams {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+amount?: number | string;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+opacity?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
+## CrossfadeParams
+
+<div class="ts-block">
+
+```dts
+interface CrossfadeParams {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number | ((len: number) => number);
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
+## DrawParams
+
+<div class="ts-block">
+
+```dts
+interface DrawParams {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+speed?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number | ((len: number) => number);
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
+## EasingFunction
+
+<div class="ts-block">
+
+```dts
+type EasingFunction = (t: number) => number;
+```
+
+
+</div>
+
+## FadeParams
+
+<div class="ts-block">
+
+```dts
+interface FadeParams {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
+## FlyParams
+
+<div class="ts-block">
+
+```dts
+interface FlyParams {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+x?: number | string;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+y?: number | string;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+opacity?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
+## ScaleParams
+
+<div class="ts-block">
+
+```dts
+interface ScaleParams {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+start?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+opacity?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
+## SlideParams
+
+<div class="ts-block">
+
+```dts
+interface SlideParams {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+axis?: 'x' | 'y';
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
+## TransitionConfig
+
+<div class="ts-block">
+
+```dts
+interface TransitionConfig {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+delay?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+duration?: number;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+easing?: EasingFunction;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+css?: (t: number, u: number) => string;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+tick?: (t: number, u: number) => void;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+</div>
+
 

--- a/packages/site-kit/src/lib/markdown/index.ts
+++ b/packages/site-kit/src/lib/markdown/index.ts
@@ -1,9 +1,6 @@
 export {
 	render_content_markdown as renderContentMarkdown,
-	replace_export_type_placeholders,
-	stringify_module,
-	stringify_type,
-	stringify_expanded_type
+	replace_export_type_placeholders
 } from './renderer';
 
 export {


### PR DESCRIPTION
Remove the `<!-- @include ... -->` syntax in favor of the existing `> XXX:` syntax. Add a new `> MODULE:` placeholder. Move some special-casing into sync script. Consolidate stuff.