### PR TITLE
Revert "constrain header width"

### DIFF
--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -162,8 +162,6 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		transition: 0.4s var(--quint-out);
 		transition-property: transform, background;
 		isolation: isolate;
-		--nav-max-width: calc(var(--sk-line-max-width) + var(--sk-page-padding-side) + 64rem);
-		padding: 0 calc(0.5 * (100vw - var(--nav-max-width)));
 	}
 
 	nav::after {


### PR DESCRIPTION
Reverts sveltejs/svelte.dev#98. On reflection I don't like this. It looks stupid on many pages, and it only _really_ looks good on the docs page. I think it's more common for a nav bar to fill the width of the window (if in doubt, look at the page you're currently on)