### PR TITLE
move edit link

### DIFF
--- a/apps/svelte.dev/src/routes/docs/[...path]/+page.svelte
+++ b/apps/svelte.dev/src/routes/docs/[...path]/+page.svelte
@@ -67,7 +67,7 @@
 		font-size: 1.4rem;
 		line-height: 1;
 		z-index: 2;
-		margin: 6rem 0 0 0;
+		margin: 6rem 0 2rem 0;
 
 		a {
 			text-decoration: none;


### PR DESCRIPTION
it's visually noisy and doesn't need to be at the top of the page