### PR TITLE
Use real italics

### DIFF
--- a/packages/site-kit/src/lib/styles/index.css
+++ b/packages/site-kit/src/lib/styles/index.css
@@ -1,3 +1,15 @@
+@import '@fontsource/cardo';
+@import '@fontsource/cardo/400-italic.css';
+@import '@fontsource/fira-mono';
+
+/* TODO figure out which weights we actually need */
+@import '@fontsource/yantramanav/100.css';
+@import '@fontsource/yantramanav/300.css';
+@import '@fontsource/yantramanav/400.css';
+@import '@fontsource/yantramanav/500.css';
+@import '@fontsource/yantramanav/700.css';
+@import '@fontsource/yantramanav/900.css';
+
 @import './tokens.css';
 @import './base.css';
 @import './text.css';

--- a/packages/site-kit/src/lib/styles/tokens.css
+++ b/packages/site-kit/src/lib/styles/tokens.css
@@ -1,14 +1,3 @@
-@import '@fontsource/cardo';
-@import '@fontsource/cardo/400-italic.css';
-@import '@fontsource/fira-mono';
-/* TODO figure out which weights we actually need */
-@import '@fontsource/yantramanav/100.css';
-@import '@fontsource/yantramanav/300.css';
-@import '@fontsource/yantramanav/400.css';
-@import '@fontsource/yantramanav/500.css';
-@import '@fontsource/yantramanav/700.css';
-@import '@fontsource/yantramanav/900.css';
-
 /*
 
 !IMPORTANT: The tokens for light and dark mode are duplicated, if you change a token for dark mode,


### PR DESCRIPTION
We were using faux italics:

<img width="849" alt="image" src="https://github.com/user-attachments/assets/35990d08-9f8b-4cc5-8403-5f4bc8c14421">

This would have been a firable offense at my old job. Looks 9000% better with this PR:

<img width="854" alt="image" src="https://github.com/user-attachments/assets/e905d1ac-9f29-49e2-8f44-112878eb86df">
