### PR TITLE
apply background to search box, not its children

### DIFF
--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -279,6 +279,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 	.search-box {
 		--padding: 1rem;
 		--background: var(--sk-back-2);
+		background: var(--background);
 		position: relative;
 		height: calc(100% - 2rem);
 		width: calc(100vw - 2rem);
@@ -358,7 +359,6 @@ It appears when the user clicks on the `Search` component or presses the corresp
 	}
 
 	.results-container {
-		background: var(--background);
 		border-radius: 0 0 var(--sk-border-radius) var(--sk-border-radius);
 		pointer-events: all;
 	}
@@ -369,7 +369,6 @@ It appears when the user clicks on the `Search` component or presses the corresp
 		font-size: 1.2rem;
 		font-weight: normal;
 		text-transform: uppercase;
-		background-color: var(--background);
 		pointer-events: all;
 	}
 

--- a/packages/site-kit/src/lib/search/SearchResultList.svelte
+++ b/packages/site-kit/src/lib/search/SearchResultList.svelte
@@ -77,7 +77,6 @@
 			position: sticky;
 			top: 0;
 			display: block;
-			background: var(--background);
 			color: var(--sk-text-4);
 			text-transform: uppercase;
 			padding: 0.5rem var(--padding);


### PR DESCRIPTION
fixes this (the pixel peeking through near the bottom left of the focused input)

<img width="154" alt="image" src="https://github.com/user-attachments/assets/76f19417-29fe-4234-a23c-3ad6f17d2739">
