### PR TITLE
non-neumorphic buttons

### DIFF
--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
@@ -117,7 +117,7 @@
 		flex-direction: column;
 
 		@media (min-width: 800px) {
-			--app-controls-h: 4rem;
+			--app-controls-h: 4.4rem;
 		}
 	}
 

--- a/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
+++ b/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
@@ -112,23 +112,34 @@
 				}
 
 				&::before {
-					box-shadow: var(--sk-raised);
+					border-radius: var(--sk-border-radius);
+					border-style: solid;
+					border-color: var(--sk-raised-color);
+					border-width: var(--sk-raised-width);
 				}
 
 				&:hover::before {
-					box-shadow: var(--sk-raised-hover);
+					border-color: var(--sk-raised-hover-color);
 				}
 
 				&:active::before {
-					box-shadow: var(--sk-raised-active);
+					border-color: var(--sk-raised-active-color);
+					border-width: var(--sk-raised-active-width);
 				}
 
 				&::after {
 					background: url($lib/icons/chevron.svg) 50% 50% no-repeat;
 					background-size: 2rem;
+					top: 0.4rem;
+					right: 0.2rem;
 					rotate: -90deg;
 					transition: rotate 0.2s;
 					transition: rotate 0.2s;
+				}
+
+				&:active::after {
+					top: 0.5rem;
+					right: 0.1rem;
 				}
 
 				h3 {

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -431,22 +431,26 @@
 				content: '';
 				position: absolute;
 				right: 0.6rem;
-				top: 0.2rem;
+				top: 0.1rem;
 				width: 2.4rem;
 				height: 2.4rem;
 				pointer-events: none;
 			}
 
 			&::before {
-				box-shadow: var(--sk-raised);
+				border-radius: var(--sk-border-radius);
+				border-style: solid;
+				border-color: var(--sk-raised-color);
+				border-width: var(--sk-raised-width);
 			}
 
 			&:hover::before {
-				box-shadow: var(--sk-raised-hover);
+				border-color: var(--sk-raised-hover-color);
 			}
 
 			&:has(summary:active)::before {
-				box-shadow: var(--sk-raised-active);
+				border-color: var(--sk-raised-active-color);
+				border-width: var(--sk-raised-active-width);
 			}
 
 			&::after {
@@ -455,6 +459,13 @@
 				rotate: -90deg;
 				transition: rotate 0.2s;
 				transition: rotate 0.2s;
+				top: 0.2rem;
+				right: 0.8rem;
+			}
+
+			&:has(summary:active)::after {
+				top: 0.3rem;
+				right: 0.7rem;
 			}
 
 			& > summary {

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -298,7 +298,7 @@ async function parse({
 		blockquote(token) {
 			let content = this.parser?.parse(token.tokens) ?? '';
 			if (content.includes('[!LEGACY]')) {
-				content = `<details class="legacy"><summary>Legacy mode</summary>${content.replace('[!LEGACY]', '')}</details>`;
+				content = `<details class="legacy"><summary><label>Legacy mode <button class="raised"></button></label></summary>${content.replace('[!LEGACY]', '')}</details>`;
 			}
 			return `<blockquote>${content}</blockquote>`;
 		}

--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -34,9 +34,6 @@ body {
 	scrollbar-width: thin;
 	scrollbar-color: var(--sk-scrollbar) transparent;
 	-webkit-tap-highlight-color: hsla(var(--sk-theme-1-hsl), 0.1);
-
-	transition: 0.5s var(--quint-out);
-	transition-property: background, background-color, background-image, border;
 }
 
 *:focus-visible {
@@ -169,18 +166,22 @@ button > svg {
 
 .raised {
 	border-radius: var(--sk-border-radius);
-	box-shadow: var(--sk-raised);
+	border-style: solid;
+	border-color: var(--sk-raised-color);
+	border-width: var(--sk-raised-width);
 
 	&:hover {
-		box-shadow: var(--sk-raised-hover);
+		border-color: var(--sk-raised-hover-color);
 	}
 
 	&:active {
-		box-shadow: var(--sk-raised-active);
+		border-color: var(--sk-raised-active-color);
+		border-width: var(--sk-raised-active-width);
 	}
 
 	&:disabled {
-		box-shadow: none;
+		border-color: transparent;
+		border-width: 1px;
 	}
 }
 

--- a/packages/site-kit/src/lib/styles/tokens.css
+++ b/packages/site-kit/src/lib/styles/tokens.css
@@ -49,6 +49,7 @@
 	--sk-back-3: hsla(0, 0%, 99%, 1);
 	--sk-back-4: hsl(0, 0%, 95%);
 	--sk-back-5: hsl(0, 0%, 92%);
+	--sk-back-6: hsl(0, 0%, 86%);
 
 	--sk-text-1: hsla(0, 0%, 0%, 0.95);
 	--sk-text-2: hsla(0, 0%, 0%, 0.88);
@@ -86,16 +87,11 @@
 	--shiki-color-background: var(--sk-back-2);
 
 	/* raised buttons */
-	--sk-raised-highlight: hsl(0 0 100 / 0.8);
-	--sk-raised-highlight-active: hsl(0 0 100 / 1);
-	--sk-raised-shadow: hsl(0 0 0 / 0.1);
-	--sk-raised-shadow-active: hsl(0 0 0 / 0.15);
-
-	--sk-raised: 1px 1px 3px var(--sk-raised-shadow), -1px -1px 3px var(--sk-raised-highlight);
-	--sk-raised-hover: 1px 1px 3px var(--sk-raised-shadow-active),
-		-1px -1px 3px var(--sk-raised-highlight-active);
-	--sk-raised-active: inset -1px -1px 2px var(--sk-raised-highlight-active),
-		inset 1px 1px 2px var(--sk-raised-shadow-active);
+	--sk-raised-color: var(--sk-back-4) var(--sk-back-5) var(--sk-back-5) var(--sk-back-4);
+	--sk-raised-width: 1px 2px 2px 1px;
+	--sk-raised-hover-color: var(--sk-back-5) var(--sk-back-6) var(--sk-back-6) var(--sk-back-5);
+	--sk-raised-active-color: var(--sk-back-6) var(--sk-back-5) var(--sk-back-5) var(--sk-back-6);
+	--sk-raised-active-width: 2px 1px 1px 2px;
 
 	&.dark {
 		color-scheme: dark;
@@ -105,6 +101,7 @@
 		--sk-back-3: hsl(0 0 12);
 		--sk-back-4: hsl(0 0 22);
 		--sk-back-5: hsl(0 0 25);
+		--sk-back-6: hsl(0 0 32);
 		--sk-back-translucent: hsla(0, 0%, 100%, 0.1);
 		--sk-theme-1-hsl: 12, 94%, 62%;
 		--sk-theme-2-hsl: 240, 8%, 44%;
@@ -139,10 +136,9 @@
 		--shiki-color-background: var(--sk-back-3);
 
 		/* raised buttons */
-		--sk-raised-highlight: hsl(0 0 100 / 0.1);
-		--sk-raised-highlight-active: hsl(0 0 100 / 0.15);
-		--sk-raised-shadow: hsl(0 0 0 / 0.3);
-		--sk-raised-shadow-active: hsl(0 0 0 / 0.22);
+		--sk-raised-color: var(--sk-back-5) var(--sk-back-3) var(--sk-back-3) var(--sk-back-5);
+		--sk-raised-hover-color: var(--sk-back-6) var(--sk-back-3) var(--sk-back-3) var(--sk-back-6);
+		--sk-raised-active-color: var(--sk-back-3) var(--sk-back-6) var(--sk-back-6) var(--sk-back-3);
 	}
 }
 


### PR DESCRIPTION
This implements @trueadm's idea of using `1px 2px 2px 1px` borders instead of box-shadow to indicate button-ness:

<img width="330" alt="image" src="https://github.com/user-attachments/assets/01bd8730-3214-4d93-a34f-688dd8765aef">

I think it works pretty well