### PR TITLE
fix: custom docs ordering

### DIFF
--- a/apps/svelte.dev/scripts/sync-docs/index.ts
+++ b/apps/svelte.dev/scripts/sync-docs/index.ts
@@ -22,7 +22,7 @@ const DOCS = path.join(dirname, '../../content/docs');
 
 const packages: Package[] = [
 	{
-		name: 'svelte',
+		name: '10-svelte',
 		local: `${REPOS}/svelte`,
 		repo: 'sveltejs/svelte',
 		pkg: 'packages/svelte',
@@ -45,7 +45,7 @@ const packages: Package[] = [
 		}
 	},
 	{
-		name: 'kit',
+		name: '20-kit',
 		local: `${REPOS}/kit`,
 		repo: 'sveltejs/kit',
 		pkg: 'packages/kit',

--- a/apps/svelte.dev/src/routes/nav.json/+server.ts
+++ b/apps/svelte.dev/src/routes/nav.json/+server.ts
@@ -21,7 +21,6 @@ async function get_nav_list(): Promise<NavigationLink[]> {
 				}))
 			}))
 		}))
-		.sort((a, b) => a.title.localeCompare(b.title)); // Svelte first
 
 	const tutorial = index.tutorial.children.map((topic) => ({
 		title: topic.metadata.title,


### PR DESCRIPTION
Fixes #250 

removes the sorting by title, as this would place the `cli` before `kit` and `svelte`.
slightly changes the `name` of our "packages" to include ordering, as we do on a lot of docs related places.

to be done: sync the docs (didn't find the branches you were using, so always got slightly modified results)