### PR TITLE
fix login

### DIFF
--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -48,7 +48,6 @@
 		"cookie": "^0.6.0",
 		"d3-geo": "^3.1.0",
 		"d3-geo-projection": "^4.0.0",
-		"devalue": "^5.0.0",
 		"do-not-zip": "^1.0.0",
 		"flexsearch": "^0.7.43",
 		"flru": "^1.0.2",

--- a/apps/svelte.dev/src/routes/(authed)/+layout.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/+layout.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
+	import { storage_key } from '../auth/_config';
 	import { set_app_context } from './app-context';
 
 	set_app_context({
-		login: () => {
-			const login_window = window.open(
-				`${window.location.origin}/auth/login`,
-				'login',
-				'width=600,height=400'
-			);
+		login: async () => {
+			window.open(`${window.location.origin}/auth/login`, 'login', 'width=600,height=400');
 
-			window.addEventListener('message', function handler(event) {
-				if (event.data.source !== 'svelte-auth') return;
-				login_window!.close();
-				window.removeEventListener('message', handler);
-				invalidateAll();
+			// we can't interact directly with opener, so we use localStorage as a side channel
+			window.addEventListener('storage', function handler(event) {
+				if (event.key === storage_key) {
+					invalidateAll();
+					window.removeEventListener('storage', handler);
+					this.localStorage.clearItem(storage_key);
+				}
 			});
 		},
 

--- a/apps/svelte.dev/src/routes/auth/_config.js
+++ b/apps/svelte.dev/src/routes/auth/_config.js
@@ -1,6 +1,2 @@
-import { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } from '$env/static/private';
-
 export const oauth = 'https://github.com/login/oauth';
-
-export const client_id = GITHUB_CLIENT_ID;
-export const client_secret = GITHUB_CLIENT_SECRET;
+export const storage_key = 'login';

--- a/apps/svelte.dev/src/routes/auth/login/+server.js
+++ b/apps/svelte.dev/src/routes/auth/login/+server.js
@@ -1,33 +1,33 @@
 import { redirect } from '@sveltejs/kit';
-import { client_id, oauth } from '../_config.js';
+import { oauth } from '../_config.js';
+import { GITHUB_CLIENT_ID } from '$env/static/private';
 
-export const GET = client_id
-	? /** @param {{url: URL}} opts */ ({ url }) => {
-			const Location =
-				`${oauth}/authorize?` +
-				new URLSearchParams({
-					scope: 'read:user',
-					client_id,
-					redirect_uri: `${url.origin}/auth/callback`
-				}).toString();
-
-			redirect(302, Location);
-		}
-	: () =>
-			new Response(
-				`
-			<body style="font-family: sans-serif; background: rgb(255,215,215); border: 2px solid red; margin: 0; padding: 1em;">
-				<h1>Missing .env file</h1>
-				<p>In order to use GitHub authentication, you will need to <a target="_blank" href="https://github.com/settings/developers">register an OAuth application</a> and create a local .env file:</p>
-				<pre>GITHUB_CLIENT_ID=[YOUR_APP_ID]\nGITHUB_CLIENT_SECRET=[YOUR_APP_SECRET]\nBASEURL=http://localhost:5173</pre>
-				<p>The <code>BASEURL</code> variable should match the callback URL specified for your app.</p>
-				<p>See also <a target="_blank" href="https://github.com/sveltejs/svelte/tree/svelte-4/sites/svelte.dev#repl-github-integration">here</a></p>
-			</body>
-		`,
-				{
-					status: 500,
-					headers: {
-						'Content-Type': 'text/html; charset=utf-8'
-					}
+export function GET({ url }) {
+	if (!GITHUB_CLIENT_ID) {
+		return new Response(
+			`
+		<body style="font-family: sans-serif; background: rgb(255,215,215); border: 2px solid red; margin: 0; padding: 1em;">
+			<h1>Missing .env file</h1>
+			<p>In order to use GitHub authentication, you will need to <a target="_blank" href="https://github.com/settings/developers">register an OAuth application</a> and create a local .env file:</p>
+			<pre>GITHUB_CLIENT_ID=[YOUR_APP_ID]\nGITHUB_CLIENT_SECRET=[YOUR_APP_SECRET]\nBASEURL=http://localhost:5173</pre>
+			<p>The <code>BASEURL</code> variable should match the callback URL specified for your app.</p>
+			<p>See also <a target="_blank" href="https://github.com/sveltejs/svelte/tree/svelte-4/sites/svelte.dev#repl-github-integration">here</a></p>
+		</body>
+	`,
+			{
+				status: 500,
+				headers: {
+					'Content-Type': 'text/html; charset=utf-8'
 				}
-			);
+			}
+		);
+	}
+
+	const params = new URLSearchParams({
+		scope: 'read:user',
+		client_id: GITHUB_CLIENT_ID,
+		redirect_uri: `${url.origin}/auth/callback`
+	});
+
+	redirect(302, `${oauth}/authorize?${params}`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       d3-geo-projection:
         specifier: ^4.0.0
         version: 4.0.0
-      devalue:
-        specifier: ^5.0.0
-        version: 5.0.0
       do-not-zip:
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
working on this so that I can properly review #275. It turns out that the staging db was paused, which was the root of #267, but beyond that the login flow seems broken because the child window (that opens when you click 'log in') tries to communicate with `window.opener` which isn't possible. Not sure if that's a new thing caused by cross-origin isolation.

Anyway we don't need direct window-to-window communication, we can hack around it with `storage` events. As soon as the child window is sent back to `/auth/callback`, we set a value in `localStorage` that the parent window is listening for; once it updates, we call `invalidateAll` and the child window closes.