### PR TITLE
invalidate snippet cache when code changes

### DIFF
--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -536,6 +536,7 @@ function get_mtime(file: string, seen = new Set<string>()) {
 
 const mtime = Math.max(
 	get_mtime(fileURLToPath(import.meta.url)),
+	fs.statSync('node_modules').mtimeMs,
 	fs.statSync('../../pnpm-lock.yaml').mtimeMs
 );
 


### PR DESCRIPTION
closes #146. This adds some crude-but-working code that determines whether the code that renders snippets is more recent than the snippet cache, and if so destroys the cache. In theory this will give us the best of all worlds — we don't need to regenerate everything on `sync-docs`, but we will also avoid deploying stale snippets