### PR TITLE
chore: upgrade cookie to 0.7.0

### DIFF
--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -47,7 +47,7 @@
 		"ansi-to-html": "^0.7.2",
 		"base64-js": "^1.5.1",
 		"codemirror": "^6.0.1",
-		"cookie": "^0.6.0",
+		"cookie": "^0.7.0",
 		"d3-geo": "^3.1.0",
 		"d3-geo-projection": "^4.0.0",
 		"do-not-zip": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(@lezer/common@1.2.2)
       cookie:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.0
+        version: 0.7.2
       d3-geo:
         specifier: ^3.1.0
         version: 3.1.1
@@ -1788,6 +1788,10 @@ packages:
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   crelt@1.0.6:
@@ -4595,6 +4599,8 @@ snapshots:
   console-control-strings@1.1.0: {}
 
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
 
   crelt@1.0.6: {}
 


### PR DESCRIPTION
closes https://github.com/sveltejs/svelte/pull/13530