### PR TITLE
fix code in links

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -291,13 +291,6 @@
 			color: inherit;
 			text-decoration: underline;
 			transition: box-shadow 0.1s ease-in-out;
-
-			/* TODO what is this for? */
-			code {
-				all: unset !important;
-				color: inherit;
-				background-color: transparent !important;
-			}
 		}
 
 		/* permalinks */


### PR DESCRIPTION
for some unfathomable reason we were stripped `<code>` elements of their styles if they were inside `<a>` elements. This made them look silly