### PR TITLE
fix: be more robust about finding sections

### DIFF
--- a/packages/site-kit/src/lib/server/content/index.ts
+++ b/packages/site-kit/src/lib/server/content/index.ts
@@ -31,12 +31,21 @@ export async function create_index(
 				'<code>$1</code>'
 			);
 
-		const sections = Array.from(body.matchAll(/^##\s+(.*)$/gm)).map((match) => {
+		let sections = Array.from(body.matchAll(/^##\s+(.*)$/gm)).map((match) => {
 			const title = match[1].replace(/`/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
 			const slug = slugify(title);
 
 			return { slug, title };
 		});
+		// If no sections found, try again with sub sections. This way we have a better "OnThisPage" list
+		if (sections.length === 0) {
+			sections = Array.from(body.matchAll(/^###\s+(.*)$/gm)).map((match) => {
+				const title = match[1].replace(/`/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+				const slug = slugify(title);
+
+				return { slug, title };
+			});
+		}
 
 		content[slug] = {
 			slug,


### PR DESCRIPTION
#322 and #331 added pages for compiler/runtime errors/warnings, but these pages are barely usable because "On this page" is empty because of missing h2 tags.

This fixes that by enhancing our sections logic: If no h2 tags are found, try again with h3 tags.