### PR TITLE
fix: correct scroll position if needed

### DIFF
--- a/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
+++ b/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
@@ -32,7 +32,30 @@
 	}
 </script>
 
-<svelte:window onscroll={update} onhashchange={() => (current = location.hash.slice(1))} />
+<svelte:window
+	onscroll={update}
+	onhashchange={() => {
+		current = location.hash.slice(1);
+		// Correct scroll position if needed
+		const active = [...headings.values()].find((entry) => entry.id === current);
+		if (active) {
+			const { top, bottom } = active.getBoundingClientRect();
+			const min = 100;
+			const max = window.innerHeight - 100;
+			if (top > max) {
+				window.scrollBy({
+					top: top - max,
+					left: 0
+				});
+			} else if (bottom < min) {
+				window.scrollBy({
+					top: bottom - min,
+					left: 0
+				});
+			}
+		}
+	}}
+/>
 
 <aside class="on-this-page">
 	<label>


### PR DESCRIPTION
For some reason that escapes me Chrome ignores the `scroll-margin-top` property. It's possible to fix it using JS even though that's not ideal. fixes #273 (the logic is taken from #96 where it was removed)

This was a bit jumpy locally in dev mode at times (tested on the "Basic markup" page), let's see how it works when deployed.

If we don't find a better solution fast then I'd merge this anyway but keep the related issue open until we find a proper non-JS fix. This is still better than not scrolling the headers into view.