### PR TITLE
remove error lines from twoslash output

### DIFF
--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -680,6 +680,13 @@ async function syntax_highlight({
 			if (check) {
 				// munge the twoslash output so that it renders sensibly. the order of operations
 				// here is important — we need to work backwards, to avoid corrupting the offsets
+
+				// first, strip out unwanted error lines
+				html = html.replace(
+					/<div class="twoslash-meta-line twoslash-error-line">[^]+?<\/div>/g,
+					'\n'
+				);
+
 				const replacements: Array<{ start: number; end: number; content: string }> = [];
 
 				for (const match of html.matchAll(/<div class="twoslash-popup-docs">([^]+?)<\/div>/g)) {


### PR DESCRIPTION
fixes #354

before:

<img width="634" alt="image" src="https://github.com/user-attachments/assets/e9b2f901-dd6c-4db9-be20-52fe1c258609">

after:

<img width="694" alt="image" src="https://github.com/user-attachments/assets/850943bb-645f-4734-9baa-11e64118c7fc">
