### PR TITLE
style: consistent nav link padding

### DIFF
--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -243,18 +243,14 @@ Top navigation bar for the application. It provides a slot for the left side, th
 				box-shadow: inset 0 -1px 0 0 currentColor;
 			}
 
+			&:not(.secondary) {
+				padding: 0.1rem 0.8rem 0 0.8rem;
+			}
+
 			&.secondary {
 				box-shadow: none;
 				line-height: 1;
 			}
-		}
-
-		& > a {
-			padding: 0.1rem 0.8rem 0 0.8rem;
-		}
-
-		& > .dropdown > a {
-			padding: 0.1rem 0.8rem 0 0.8rem;
 		}
 	}
 


### PR DESCRIPTION
Closes #456 

The nav links that _aren't_ dropdowns were receiving x-axis padding causing inconsistent spacing between nav links.

Before:
![CleanShot 2024-10-18 at 18 49 53@2x](https://github.com/user-attachments/assets/17a24fd9-e5f2-437d-8936-8e9caaaa8ad9)

After:
![CleanShot 2024-10-18 at 18 50 10@2x](https://github.com/user-attachments/assets/19432524-714b-4ff1-9735-b138a5d0f84a)
