### PR TITLE
style: sidebar spacing idea

### DIFF
--- a/packages/site-kit/src/lib/docs/DocsContents.svelte
+++ b/packages/site-kit/src/lib/docs/DocsContents.svelte
@@ -74,7 +74,7 @@
 	li {
 		display: block;
 		margin: 0;
-		margin-bottom: 4rem;
+		margin-bottom: 3.5rem;
 	}
 
 	li:last-child {
@@ -88,6 +88,7 @@
 		padding: 0;
 		color: var(--sk-text-2);
 		user-select: none;
+		padding: 0.15rem 0;
 	}
 
 	h3 {


### PR DESCRIPTION
This gives the individual nav items just a _wee_ bit of padding on the y-axis (0.15rem) and reduces the spacing between the sections by 0.5rem. Feels a bit less squished. Just an idea!

Before:
![CleanShot 2024-10-18 at 19 03 16@2x](https://github.com/user-attachments/assets/4537db37-55c3-408c-b43c-490dc17bd96b)

After:
![CleanShot 2024-10-18 at 19 04 09@2x](https://github.com/user-attachments/assets/b55813bc-0561-4441-bf42-c515ed9be121)
