### PR TITLE
style: font antialiasing (better dark-mode font)

### DIFF
--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -5,6 +5,7 @@ html {
 	-ms-overflow-style: -ms-autohiding-scrollbar;
 	box-sizing: border-box;
 	border-collapse: collapse;
+	-webkit-font-smoothing: antialiased;
 }
 
 html,


### PR DESCRIPTION
This solves the font-weight issue in dark mode.
![Screenshot 2024-10-18 at 11 59 29 PM](https://github.com/user-attachments/assets/4d6e483c-1182-478d-a681-0d3feb263e9d)

