### PR TITLE
fix: migrate button, repl type and upgrade to ^5.0.0

### DIFF
--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/AppControls.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/AppControls.svelte
@@ -15,7 +15,7 @@
 	interface Props {
 		examples: Array<{ title: string; examples: any[] }>;
 		user: User | null;
-		repl: any; // TODO
+		repl: ReturnType<typeof Repl>;
 		gist: Gist;
 		name: string;
 		modified: boolean;
@@ -39,7 +39,7 @@
 	let saving = $state(false);
 	let justSaved = $state(false);
 	let justForked = $state(false);
-	let select: any; // TODO why can't i do `select: SelectIcon`?
+	let select: ReturnType<typeof SelectIcon>;
 
 	function wait(ms: number) {
 		return new Promise((f) => setTimeout(f, ms));

--- a/packages/editor/src/lib/Workspace.svelte.ts
+++ b/packages/editor/src/lib/Workspace.svelte.ts
@@ -196,7 +196,7 @@ export class Workspace {
 			return true;
 		});
 
-		this.#current = next;
+		this.#select(next);
 
 		this.#onreset?.(this.#files);
 	}
@@ -275,10 +275,9 @@ export class Workspace {
 			if (!file) {
 				throw new Error(`Invalid selection ${selected}`);
 			}
-
-			this.#current = file as File;
+			this.#select(file as File);
 		} else {
-			this.#current = first;
+			this.#select(first);
 		}
 
 		this.#files = files;
@@ -452,11 +451,17 @@ export class Workspace {
 		const existing = state.doc.toString();
 
 		if (file.contents !== existing) {
+			const current_cursor_position = this.#view?.state.selection.ranges[0].from!;
+
 			const transaction = state.update({
 				changes: {
 					from: 0,
 					to: existing.length,
 					insert: file.contents
+				},
+				selection: {
+					anchor: current_cursor_position,
+					head: current_cursor_position
 				}
 			});
 


### PR DESCRIPTION
The update to `this.#current` is needed when the value doesn't come from codemirror (like the migrate button) or else codemirror will not update.

This also updated to svelte 5 and fixes a typing issue in `+page.svelte`