### PR TITLE
fix: testemonial images on safari

### DIFF
--- a/apps/svelte.dev/src/routes/_home/Testimonials.svelte
+++ b/apps/svelte.dev/src/routes/_home/Testimonials.svelte
@@ -73,7 +73,7 @@
 			width: 100%;
 			top: 0;
 			overflow: hidden;
-			filter: drop-shadow(0.2rem 0.4rem 2rem rgb(0 0 0 / 0.3));
+			filter: drop-shadow(0.2rem 0.4rem 1.6rem rgb(0 0 0 / 0.2));
 			transform: translate3d(0, 0, 0);
 			transition-property: filter, scale;
 			transition-duration: 0.2s;
@@ -100,7 +100,7 @@
 
 			&:hover {
 				scale: 1.05;
-				filter: drop-shadow(0.2rem 0rem 4rem rgb(0 0 0 / 0.3));
+				filter: drop-shadow(0.2rem 0.4rem 2.4rem rgb(0 0 0 / 0.2));
 			}
 		}
 


### PR DESCRIPTION
- changed `filter: drop-shadow` to `box-shadow`
- added a subtly larger shadow to the hover transition
- moved the shadow from the `a` to the `img` and removed `overflow: hidden` from `a`
- changed `filter: none` to `filter: grayscale(0)` to fix the transition on safari

`overflow: hidden` caused safari to clip the shadows regardless of whether they were defined on the `a` or `img` tag for both `drop` and `box` shadows.