### PR TITLE
convert from hsl to rgb/hex

### DIFF
--- a/packages/site-kit/src/lib/styles/tokens.css
+++ b/packages/site-kit/src/lib/styles/tokens.css
@@ -110,8 +110,8 @@
 	--sk-text-warning: var(--sk-text-warning-hsl);
 
 	/* used for coloured backgrounds e.g. blockquotes */
-	--sk-back-translucent: rgba(0, 0%, 0%, 0.1);
-	--sk-text-translucent: rgba(0, 0%, 0%, 0.7);
+	--sk-back-translucent: rgba(0, 0, 0, 0.1);
+	--sk-text-translucent: rgba(0, 0, 0, 0.7);
 
 	/* overrides */
 	--shiki-color-background: var(--sk-back-2);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte.dev/issues/422#issuecomment-2429151144. Turns out Safari fixed hsl support in v18, before that it is majorly broken.