### PR TITLE
fix:playground mobile overflow

### DIFF
--- a/packages/repl/src/lib/Repl.svelte
+++ b/packages/repl/src/lib/Repl.svelte
@@ -204,6 +204,7 @@
 		position: relative;
 		flex: 1;
 		height: 100%;
+		min-height: 0;
 		background: var(--sk-back-1);
 		padding: 0;
 


### PR DESCRIPTION
Fixed an issue, that caused hiding the input/output switch on mobiles:

![image](https://github.com/user-attachments/assets/a8295bf9-fa73-4f7b-b50e-0057d0831f29)

the fix: 
```css
.container {
  min-height: 0;
}
```


> By default, the container cannot be smaller than the size of its content.
> Its initial size is set to min-height: auto.

https://github.com/user-attachments/assets/f423a149-5a68-4731-9c97-f36400803053

Simple fix but hope it helps,
ly Rich <33