### PR TITLE
Fix: long <code> elements overflow mobile Safari, shows horizontal scroll bar

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -101,6 +101,7 @@
 
 		code:not(pre *),
 		kbd {
+			line-break: normal;
 			white-space: pre-wrap;
 			padding: 0.2rem 0.4rem;
 			margin: 0 0.2rem;


### PR DESCRIPTION
## Issue

Inside the "Svelte 5 Migration Guide" page, under the "Modern Browser Required" section, there is a list of inline `<code>` elements (starting with `clientWidth`...) that horizontally overflow on Mobile Safari (iOS 18.0.1), causing a horizontal scrollbar to appear.

## Change summary

Inside the `<Text>` component, adding the `line-break: normal;` property to the relevant CSS selector allows the inline `<code>` elements to wrap with the text as expected, eliminating the horizontal scroll bar on the page mentioned above.

https://developer.mozilla.org/en-US/docs/Web/CSS/line-break

## Screenshots

BEFORE:

![IMG_3774](https://github.com/user-attachments/assets/650153c3-8344-47ed-88b8-e0a3710f3e05)

AFTER:

![IMG_3779](https://github.com/user-attachments/assets/b70f141d-aee5-487b-bb13-6ebebb4e21ed)
