### PR TITLE
fix: layout shift behind command+k search

### DIFF
--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -26,6 +26,8 @@ It appears when the user clicks on the `Search` component or presses the corresp
 	let search: any = $state(null);
 	let recent_searches: any[] = $state([]);
 
+	let last_scroll_position: number | null = null;
+
 	let worker: Worker;
 	let ready = $state(false);
 
@@ -68,9 +70,9 @@ It appears when the user clicks on the `Search` component or presses the corresp
 	async function close() {
 		if ($searching) {
 			$searching = false;
-			const scroll = -parseInt(document.body.style.top || '0');
+			const scroll = last_scroll_position || 0;
+			last_scroll_position = null;
 			document.body.style.position = '';
-			document.body.style.top = '';
 			document.body.tabIndex = -1;
 			document.body.focus();
 			document.body.removeAttribute('tabindex');
@@ -108,10 +110,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 
 	$effect(() => {
 		if ($searching) {
-			document.body.style.top = `-${window.scrollY}px`;
-			document.body.style.position = 'fixed';
-
-			$overlay_open = true;
+			last_scroll_position = window.scrollY;
 		}
 	});
 </script>

--- a/packages/site-kit/src/lib/stores/nav.ts
+++ b/packages/site-kit/src/lib/stores/nav.ts
@@ -14,8 +14,10 @@ overlay_open.subscribe((value) => {
 	if (value) {
 		// Disable root from scrolling
 		document.documentElement.style.overflow = 'hidden';
+		document.documentElement.style.scrollbarGutter = 'stable';
 	} else {
 		// Enable root to scroll
 		document.documentElement.style.overflow = '';
+		document.documentElement.style.scrollbarGutter = '';
 	}
 });


### PR DESCRIPTION
This fixes the layout shift behind cmd+k SearchBox when it is toggled on-off. Words in paragraphs jump and images scale.

- Added `scrollbar-gutter` to the html when `overflow` is `hidden` by the `overlay_open` store. This allows body size to remain stable. 
- Changed body positioning from `fixed` to `absolute` to account for the `scrollbar-gutter`.
- Removed `top` from frozen body to account for the new positioning.
- Added local state to the SearchBox because the last scroll position is not stored in the `top` style declaration of the body anymore.

---

`scrollbar-gutter` is not yet supported in Safari, this means the experience is unchanged for Safari users.