### PR TITLE
fix: ensure shared file is resolved properly in all situations

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -256,6 +256,8 @@ async function get_bundle(
 				}
 			}
 
+			if (importee === shared_file) return importee;
+
 			// importing from another file in REPL
 			if (local_files_lookup.has(importee) && (!importer || local_files_lookup.has(importer)))
 				return importee;
@@ -394,7 +396,7 @@ async function get_bundle(
 					result.js.code +=
 						'\n\n' +
 						`
-					import { styles as $$_styles } from './__shared.js';
+					import { styles as $$_styles } from '${shared_file}';
 					const $$__style = document.createElement('style');
 					$$__style.textContent = ${JSON.stringify(result.css.code)};
 					document.head.append($$__style);
@@ -476,6 +478,8 @@ async function get_bundle(
 
 export type BundleResult = ReturnType<typeof bundle>;
 
+const shared_file = '$$__shared__.js';
+
 async function bundle({
 	uid,
 	files,
@@ -500,7 +504,7 @@ async function bundle({
 			version.split('.')[0] >= '5'
 				? `
 			import { unmount as u } from 'svelte';
-			import { styles } from './__shared.js';
+			import { styles } from '${shared_file}';
 			export { mount, untrack } from 'svelte';
 			export {default as App} from './App.svelte';
 			export function unmount(component) {
@@ -509,7 +513,7 @@ async function bundle({
 			}
 		`
 				: `
-			import { styles } from './__shared.js';
+			import { styles } from '${shared_file}';
 			export {default as App} from './App.svelte';
 			export function mount(component, options) {
 				return new component(options);
@@ -525,10 +529,10 @@ async function bundle({
 		text: true
 	});
 
-	lookup.set('./__shared.js', {
+	lookup.set(shared_file, {
 		type: 'file',
-		name: '__shared.js',
-		basename: '__shared.js',
+		name: shared_file,
+		basename: shared_file,
 		contents: `
 			export let styles = [];
 		`,


### PR DESCRIPTION
using a relative import means it may be relatively imported from within a node module, which leads to wrong results

fixes #555

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
