### PR TITLE
fix: redirect learn.svelte.dev homepage for svelte.dev/tutorial

### DIFF
--- a/apps/learn.svelte.dev/vercel.json
+++ b/apps/learn.svelte.dev/vercel.json
@@ -570,6 +570,10 @@
 			"destination": "https://svelte.dev/tutorial/kit/next-steps"
 		},
 		{
+			"source": "/",
+			"destination": "https://svelte.dev/tutorial"
+		},
+		{
 			"source": "/(.*)",
 			"destination": "https://svelte.dev/$1"
 		}


### PR DESCRIPTION
closes #564
