### PR TITLE
fix: speed up build by ensuring stable cache

### DIFF
--- a/apps/svelte.dev/content/tutorial/03-sveltekit/02-routing/01-pages/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/02-routing/01-pages/index.md
@@ -2,7 +2,7 @@
 title: Pages
 ---
 
-SvelteKit uses x filesystem-based routing, which means that the _routes_ of your app — in other words, what the app should do when a user navigates to a particular URL — are defined by the directories in your codebase.
+SvelteKit uses filesystem-based routing, which means that the _routes_ of your app — in other words, what the app should do when a user navigates to a particular URL — are defined by the directories in your codebase.
 
 Every `+page.svelte` file inside `src/routes` creates a page in your app. In this app we currently have one page — `src/routes/+page.svelte`, which maps to `/`. If we navigate to `/about`, we'll see a 404 Not Found error.
 

--- a/apps/svelte.dev/content/tutorial/03-sveltekit/02-routing/01-pages/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/02-routing/01-pages/index.md
@@ -2,7 +2,7 @@
 title: Pages
 ---
 
-SvelteKit uses filesystem-based routing, which means that the _routes_ of your app — in other words, what the app should do when a user navigates to a particular URL — are defined by the directories in your codebase.
+SvelteKit uses x filesystem-based routing, which means that the _routes_ of your app — in other words, what the app should do when a user navigates to a particular URL — are defined by the directories in your codebase.
 
 Every `+page.svelte` file inside `src/routes` creates a page in your app. In this app we currently have one page — `src/routes/+page.svelte`, which maps to `/`. If we navigate to `/about`, we'll see a 404 Not Found error.
 

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -43,7 +43,7 @@ if (!fs.existsSync(original_file)) {
 			process.cwd()
 	);
 }
-hash_graph(hash, fileURLToPath(original_file));
+hash_graph(hash, original_file);
 const digest = hash.digest().toString('base64').replace(/\//g, '-');
 
 /**

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
 import { createHash, Hash } from 'node:crypto';
 import fs from 'node:fs';
+import process from 'node:process';
 import path from 'node:path';
 import ts from 'typescript';
 import * as marked from 'marked';
@@ -34,8 +35,13 @@ const hash = createHash('sha256');
 hash.update(fs.readFileSync('../../pnpm-lock.yaml', 'utf-8'));
 // CAREFUL: update this URL in case you ever move this file or start the dev/build process from another directory
 const original_file = '../../packages/site-kit/src/lib/markdown/renderer.ts';
-if (fs.existsSync(original_file)) {
-	throw new Error('Update the path to the markdown renderer code. Current value: ' + original_file);
+if (!fs.existsSync(original_file)) {
+	throw new Error(
+		'Update the path to the markdown renderer code. Current value: ' +
+			original_file +
+			' | Current cwd: ' +
+			process.cwd()
+	);
 }
 hash_graph(hash, fileURLToPath(original_file));
 const digest = hash.digest().toString('base64').replace(/\//g, '-');

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -566,6 +566,7 @@ function find_nearest_node_modules(file: string): string | null {
 function hash_graph(hash: Hash, file: string, seen = new Set<string>()) {
 	if (seen.has(file)) return;
 	seen.add(file);
+	console.log('including', file, 'in hash');
 
 	const content = fs.readFileSync(file, 'utf-8');
 

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -32,6 +32,7 @@ const hash = createHash('sha256');
 hash.update(fs.readFileSync('../../pnpm-lock.yaml', 'utf-8'));
 hash_graph(hash, fileURLToPath(import.meta.url));
 const digest = hash.digest().toString('base64').replace(/\//g, '-');
+console.log('hash is', digest);
 
 /**
  * Utility function to work with code snippet caching.
@@ -84,6 +85,8 @@ async function create_snippet_cache() {
 				if (fs.existsSync(file)) {
 					snippet = fs.readFileSync(file, 'utf-8');
 					cache.set(source, snippet);
+				} else {
+					console.log('cache miss');
 				}
 			}
 
@@ -192,7 +195,9 @@ export async function render_content_markdown(
 	const headings: string[] = [];
 	const { check = true } = options ?? {};
 
-	return await transform(body, {
+	const time = Date.now();
+
+	const res = await transform(body, {
 		async walkTokens(token) {
 			if (token.type === 'code') {
 				if (snippets.get(token.text)) return;
@@ -316,6 +321,11 @@ export async function render_content_markdown(
 			return `<blockquote>${content}</blockquote>`;
 		}
 	});
+
+	if (!filename.startsWith('<two'))
+		console.log('rendering ', filename, 'took', Date.now() - time, 'ms');
+
+	return res;
 }
 
 /**


### PR DESCRIPTION
Our builds got slower because the cache hash was always different. This happened because the dependencies were calculated based on the generated code after Vite compiled it, i.e. it would check stuff in `.svelte-kit/output/server/chunks/...js`. This seems to have worked fine for a while, but now Vite mashes things up such that code from `svelte.dev/src/lib/server/content.ts` is mixed in, which has loads of Vite hashes in it, and so the file content is always different. That in turn means our hash is always different, and so the snippet cache never hits.

The pragmatic solution is to hard-code the path to the original file and add a sanity check to ensure it's still accurate.