### PR TITLE
fix: disable nav scroll while menu is open

### DIFF
--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -47,6 +47,10 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		last_scroll = scroll;
 		hash_changed = false;
 	}
+
+	$effect(() => {
+		document.body.style.overflow = open ? 'hidden' : 'scroll';
+	})
 </script>
 
 <svelte:window

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -50,7 +50,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 
 	$effect(() => {
 		document.body.style.overflow = open ? 'hidden' : 'scroll';
-	})
+	});
 </script>
 
 <svelte:window


### PR DESCRIPTION
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

Disables scrolling while the nav menu is open. Solves #515, where the bug is better described in-depth. Accomplished by setting the body's `overflow` style to 'hidden' when the menu is open.

![image](https://github.com/user-attachments/assets/7f0fee88-2691-4576-895c-3b73e4d2458e)
