### PR TITLE
chore: Fix argument name in inline event handler

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/index.md
@@ -16,7 +16,7 @@ You can also declare event handlers inline:
 </script>
 
 <div
-	onpointermove={+++(e) => {
+	onpointermove={+++(event) => {
 		m.x = event.clientX;
 		m.y = event.clientY;
 	}+++}


### PR DESCRIPTION
In [Basic Svelte / Events / inline handlers](https://svelte.dev/tutorial/svelte/inline-handlers):

Event handler has incorrect argument. Works as is because of (deprecated) `Window.event` (I think). 
