### PR TITLE
fix: improve SvelteKit redirects

### DIFF
--- a/apps/kit.svelte.dev/vercel.json
+++ b/apps/kit.svelte.dev/vercel.json
@@ -8,12 +8,15 @@
 		},
 		{
 			"source": "/docs/modules",
-			"destination": "https://svelte.dev/docs/kit/@sveltejs-kit",
-			"permanent": true
+			"destination": "https://svelte.dev/docs/kit/@sveltejs-kit"
 		},
 		{
 			"source": "/docs/types",
-			"destination": "https://svelte.dev/docs/kit/@sveltejs-kit",
+			"destination": "https://svelte.dev/docs/kit/@sveltejs-kit"
+		},
+		{
+			"source": "/docs",
+			"destination": "https://svelte.dev/docs/kit",
 			"permanent": true
 		},
 		{


### PR DESCRIPTION
closes https://github.com/sveltejs/svelte.dev/issues/581

also removes `permanent` from two redirects that are sub-optimal and can be improved