### PR TITLE
docs: fix pointer move event parameter for consistency

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/+assets/app-b/src/lib/App.svelte
@@ -3,9 +3,9 @@
 </script>
 
 <div
-	onpointermove={(e) => {
-		m.x = e.clientX;
-		m.y = e.clientY;
+	onpointermove={(event) => {
+		m.x = event.clientX;
+		m.y = event.clientY;
 	}}
 >
 	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}


### PR DESCRIPTION
- Changed event parameter from 'e' to 'event' in onpointermove handler for consistency with instructions.

https://svelte.dev/tutorial/svelte/inline-handlers