### PR TITLE
docs: remove hidden overlay on snippet controls

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -123,10 +123,10 @@
 				align-items: center;
 				position: absolute;
 				top: 0;
+				right: 0;
 				height: var(--height);
 				padding: 0.3rem 0.5rem 0.3rem 1rem;
 				gap: 0.5rem;
-				width: 100%;
 				z-index: 2;
 				justify-content: end;
 				box-sizing: border-box;


### PR DESCRIPTION
## Problem
Snippet `controls` element without the `filename` children overlays the actual snippet code and the first line becomes hard to select and downgrades the UX.

This happens because `controls` div has full width and `z-index: 2` which makes content under it hardly selectable.

![image](https://github.com/user-attachments/assets/22eef5c7-af3d-44c8-9be4-1cb469b9cb1f)

## Solution
Remove the 100% width and make the width auto according to the contents of its children + add the `right: 0` position to be placed in the top right corner. 

This solution works for both types:
- Without filename ![image](https://github.com/user-attachments/assets/91eeec2e-678a-4bbb-bc5d-f54a5ccae11d)
- With filename (width grows automatically) ![image](https://github.com/user-attachments/assets/d0b2130f-8d5a-431e-8baa-6a93c0adfd48)


