### PR TITLE
fix: make tutorial sections more visible

### DIFF
--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/Controls.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/Controls.svelte
@@ -97,4 +97,9 @@
 		padding: 0 1rem;
 		font: var(--sk-font-ui-small);
 	}
+
+	option:disabled {
+		color: var(--sk-text-1);
+		font-weight: bold;
+	}
 </style>


### PR DESCRIPTION
the default grayed-out styling makes it super hard to quickly find what you're looking for. This gives them a black and bold styling, which better fits their use case of separating exercises into sections.
