### PR TITLE
fix: add more svelte.dev redirects

### DIFF
--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -23,7 +23,10 @@ const mappings = new Map([
 	['/docs/svelte-components', '/docs/svelte/svelte-files'],
 	['/docs/svelte-easing', '/docs/svelte/svelte-easing'],
 	['/docs/svelte-motion', '/docs/svelte/svelte-motion'],
-	['/docs/svelte-register', 'https://github.com/sveltejs/svelte/blob/svelte-4/documentation/docs/06-legacy/01-svelte-register.md'],
+	[
+		'/docs/svelte-register',
+		'https://github.com/sveltejs/svelte/blob/svelte-4/documentation/docs/06-legacy/01-svelte-register.md'
+	],
 	['/docs/svelte-store', '/docs/svelte/svelte-store'],
 	['/docs/svelte-transition', '/docs/svelte/svelte-transition'],
 	['/docs/typescript', '/docs/svelte/typescript'],

--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -2,12 +2,32 @@ import { redirect } from '@sveltejs/kit';
 
 const mappings = new Map([
 	['/docs/accessibility-warnings', '/docs/svelte/compiler-warnings'],
+	['/docs/basic-markup', '/docs/svelte/basic-markup'],
+	['/docs/client-side-component-api', '/docs/svelte/legacy-component-api'],
+	// no good mapping for this one
 	['/docs/component-directives', '/docs/svelte/svelte-files'],
 	['/docs/custom-elements-api', '/docs/svelte/custom-elements'],
+	// no good mapping for this one
 	['/docs/element-directives', '/docs/svelte/basic-markup'],
+	['/docs/introduction', '/docs/svelte/overview'],
+	// no good mapping for this one
 	['/docs/logic-blocks', '/docs/svelte/basic-markup'],
-	['/docs/svelte-components', '/docs/svelte/svelte-files'],
+	['/docs/server-side-component-api', '/docs/svelte/legacy-component-api'],
+	// no good mapping for this one
+	['/docs/special-elements', '/docs/svelte/svelte-window'],
 	['/docs/special-tags', '/docs/svelte/basic-markup'],
+	['/docs/svelte', '/docs/svelte/svelte'],
+	['/docs/svelte-action', '/docs/svelte/svelte-action'],
+	['/docs/svelte-animate', '/docs/svelte/svelte-animate'],
+	['/docs/svelte-compiler', '/docs/svelte/svelte-compiler'],
+	['/docs/svelte-components', '/docs/svelte/svelte-files'],
+	['/docs/svelte-easing', '/docs/svelte/svelte-easing'],
+	['/docs/svelte-motion', '/docs/svelte/svelte-motion'],
+	['/docs/svelte-register', 'https://github.com/sveltejs/svelte/blob/svelte-4/documentation/docs/06-legacy/01-svelte-register.md'],
+	['/docs/svelte-store', '/docs/svelte/svelte-store'],
+	['/docs/svelte-transition', '/docs/svelte/svelte-transition'],
+	['/docs/typescript', '/docs/svelte/typescript'],
+	['/docs/v4-migration-guide', '/docs/svelte/v4-migration-guide'],
 	['/faq', '/docs/svelte/faq']
 ]);
 


### PR DESCRIPTION
continuing work on https://github.com/sveltejs/svelte.dev/issues/540

It seems I duplicated some existing redirects, but I'm not sure which ones or where they live

https://svelte.dev/docs/svelte-easing already redirects, but https://svelte.dev/docs/typescript doesn't. Any idea where the first redirect lives?