### PR TITLE
fix: typo in deferred-transitions tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-a/src/lib/App.svelte
@@ -24,7 +24,7 @@
 
 			todos.push({
 				done: false,
-				text: e.currentTarget.value
+				description: e.currentTarget.value
 			});
 
 			e.currentTarget.value = '';


### PR DESCRIPTION
There is wrong todo key for description in tutorial.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
