### PR TITLE
fix: ensure right code is copied

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -33,7 +33,9 @@
 				.find((node) => (node as HTMLElement).classList.contains('code-block')) as HTMLElement;
 
 			const ts = !!parent.querySelector('.ts-toggle:checked');
-			const code = parent.querySelector(`pre:${ts ? 'last' : 'first'}-of-type code`) as HTMLElement;
+			const code = parent.querySelector(
+				`pre[data-language]:${ts ? 'last' : 'first'}-of-type code`
+			) as HTMLElement;
 
 			navigator.clipboard.writeText(get_text(code));
 		}


### PR DESCRIPTION
first/last pre isn't enough, as there can be nested pre tags due to shiki

Fixes #611
