### PR TITLE
docs:  add {todo.done} to class:done in TodoList.svelte code snippet

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/index.md
@@ -24,7 +24,7 @@ Then, add them to the `<li>` element, using the `todo.id` property as a key to m
 ```svelte
 /// file: TodoList.svelte
 <li
-	class:done
+	class:done={todo.done}
 	+++in:receive={{ key: todo.id }}+++
 	+++out:send={{ key: todo.id }}+++
 >


### PR DESCRIPTION
on the tutorial page the code snippet for `TodoList.svelte` is:
```svelte
<li
  class:done
  in:receive={{ key: todo.id }}
  out:send={{ key: todo.id }}
>
```
it should look:
```svelte
<li
  class:done={todo.done}
  in:receive={{ key: todo.id }}
  out:send={{ key: todo.id }}
>
```
if copied and pasted, it gives:
`done is not defined in TodoList.svelte in App.svelte`
[link to tutorial page](https://svelte.dev/tutorial/svelte/deferred-transitions)

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
