### PR TITLE
fix: unset overflow when nav is closed

### DIFF
--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -49,7 +49,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 	}
 
 	$effect(() => {
-		document.body.style.overflow = open ? 'hidden' : 'scroll';
+		document.body.style.overflow = open ? 'hidden' : '';
 	});
 </script>
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

Since https://github.com/sveltejs/svelte.dev/pull/576 there are vertical and horizontal scrollbars around the whole page on desktop.
We should rather unset overflow (or set it to 'auto') instead of setting it to 'scroll' when the nav is closed.