### PR TITLE
Add 'docs:' search filter

### DIFF
--- a/packages/site-kit/src/lib/search/search.ts
+++ b/packages/site-kit/src/lib/search/search.ts
@@ -86,6 +86,7 @@ export function search(query: string): BlockGroup[] {
 
 	for (const block of blocks) {
 		const breadcrumbs = block.breadcrumbs.slice(0, 2);
+
 		const group = (groups[breadcrumbs.join('::')] ??= {
 			breadcrumbs,
 			blocks: []


### PR DESCRIPTION
**What:** 
 A way to only search documentation results in the global search bar.
 
**Why:** 
Satisfies Issue #661

**How:** 
To test, open the search bar from anywhere, type in a phrase like "welcome" which will show both Docs and Tutorials results, then type "docs:welcome" and it will only show documentation results with that phrase.