### PR TITLE
styles: add transitions when switching between dark and light mode

### DIFF
--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -28,6 +28,7 @@ body {
 }
 
 * {
+	transition: color 0.5s, background 0.5s;
 	box-sizing: inherit;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
This adds a basic CSS transition to all elements for when dark/light mode is toggled. 

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time.
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
