### PR TITLE
pin announcement blog post

### DIFF
--- a/apps/svelte.dev/content/blog/2024-10-22-svelte-5-is-alive.md
+++ b/apps/svelte.dev/content/blog/2024-10-22-svelte-5-is-alive.md
@@ -3,6 +3,7 @@ title: Svelte 5 is alive
 description: Our biggest release yet
 author: The Svelte team
 authorURL: https://svelte.dev/
+pinnedUntil: 2024-11-15
 ---
 
 After almost 18 months of development, comprising thousands of commits from dozens of contributors, Svelte 5 is finally stable.

--- a/apps/svelte.dev/src/lib/server/content.ts
+++ b/apps/svelte.dev/src/lib/server/content.ts
@@ -24,6 +24,9 @@ function format_date(date: string) {
 	return `${months[+m - 1]} ${+d} ${y}`;
 }
 
+const now = new Date();
+const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
 export const blog_posts = index.blog.children
 	.map((post) => {
 		const authors: Array<{ name: string; url: string }> = [];
@@ -45,10 +48,17 @@ export const blog_posts = index.blog.children
 			...post,
 			date,
 			date_formatted: format_date(date),
-			authors
+			authors,
+			pinned: post.metadata.pinnedUntil ? post.metadata.pinnedUntil > today : false
 		};
 	})
-	.sort((a, b) => (a.date < b.date ? 1 : -1));
+	.sort((a, b) => {
+		if (!!a.pinned !== !!b.pinned) {
+			return a.pinned ? -1 : 1;
+		}
+
+		return a.date < b.date ? 1 : -1;
+	});
 
 /**
  * Create docs index, which is basically the same structure as the original index


### PR DESCRIPTION
This gives us the ability to pin a blog post to the top of `/blog`. If multiple posts are pinned simultaneously (i.e. they have a `pinnedUntil` in the future), the most recently published wins.