### PR TITLE
docs: use runes instead of old syntax in `tutorial/custom-css-transitions`

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/index.md
@@ -48,7 +48,7 @@ We can get a lot more creative though. Let's make something truly gratuitous:
 	import { fade } from 'svelte/transition';
 	+++import { elasticOut } from 'svelte/easing';+++
 
-	let visible = true;
+	let visible = $state(true);
 
 	function spin(node, { duration }) {
 		return {


### PR DESCRIPTION
### I have updated the old syntax to use the new RUNE syntax

```js
--let visible = true;--
++let visible = $state(true);++
```