### PR TITLE
blur active element instead of focusing document

### DIFF
--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -74,7 +74,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 			last_scroll_position = null;
 			document.body.style.position = '';
 			document.body.tabIndex = -1;
-			document.body.focus();
+			(document.activeElement as HTMLElement)?.blur();
 			document.body.removeAttribute('tabindex');
 			window.scrollTo(0, scroll);
 


### PR DESCRIPTION
closes #664. Instead of actively focusing the `<body>` when the search box is closed, just blur whatever the active element is. Has the same effect in terms of [SFNSP](https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point), but doesn't cause an unwanted focus ring to appear