### PR TITLE
docs: replace '(' with '{' in snippet tag

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/02-snippets/03-implicit-snippet-props/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/02-snippets/03-implicit-snippet-props/index.md
@@ -37,7 +37,7 @@ Any content inside a component that is _not_ part of a declared snippet becomes 
 
 ```svelte
 /// file: App.svelte
----(#snippet header()}---
+---{#snippet header()}---
 <header>
 	<span class="color"></span>
 	<span class="name">name</span>


### PR DESCRIPTION
### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
