### PR TITLE
Nicer ast view

### DIFF
--- a/packages/repl/src/lib/Output/AstNode.svelte
+++ b/packages/repl/src/lib/Output/AstNode.svelte
@@ -116,21 +116,13 @@
 				{/if}
 			</summary>
 
-			{#if is_array}
-				<ul>
-					{#each value as v}
-						<AstNode value={v} {path_nodes} {autoscroll} depth={depth + 1} />
-					{/each}
-				</ul>
-				<span>]</span>
-			{:else}
-				<ul>
-					{#each Object.entries(value) as [k, v]}
-						<AstNode key={k} value={v} {path_nodes} {autoscroll} depth={depth + 1} />
-					{/each}
-				</ul>
-				<span>}</span>
-			{/if}
+			<ul>
+				{#each Object.entries(value) as [k, v]}
+					<AstNode key={!is_array && k} value={v} {path_nodes} {autoscroll} depth={depth + 1} />
+				{/each}
+			</ul>
+
+			<span>{is_array ? ']' : '}'}</span>
 		</details>
 	{/if}
 </li>

--- a/packages/repl/src/lib/Output/AstNode.svelte
+++ b/packages/repl/src/lib/Output/AstNode.svelte
@@ -118,7 +118,13 @@
 
 			<ul>
 				{#each Object.entries(value) as [k, v]}
-					<AstNode key={!is_array && k} value={v} {path_nodes} {autoscroll} depth={depth + 1} />
+					<AstNode
+						key={is_array ? undefined : k}
+						value={v}
+						{path_nodes}
+						{autoscroll}
+						depth={depth + 1}
+					/>
 				{/each}
 			</ul>
 

--- a/packages/repl/src/lib/Output/AstNode.svelte
+++ b/packages/repl/src/lib/Output/AstNode.svelte
@@ -9,20 +9,16 @@
 	interface Props {
 		key?: string;
 		value: Ast;
-		collapsed?: boolean;
+		root?: boolean;
 		path_nodes?: Ast[];
 		autoscroll?: boolean;
 	}
 
-	let {
-		key = '',
-		value,
-		collapsed = $bindable(true),
-		path_nodes = [],
-		autoscroll = true
-	}: Props = $props();
+	let { key = '', value, root = false, path_nodes = [], autoscroll = true }: Props = $props();
 
 	const { toggleable } = get_repl_context();
+
+	let collapsed = $state(!root);
 
 	let list_item_el = $state() as HTMLLIElement;
 

--- a/packages/repl/src/lib/Output/AstView.svelte
+++ b/packages/repl/src/lib/Output/AstView.svelte
@@ -65,7 +65,7 @@
 		<code>
 			{#if typeof ast === 'object'}
 				<ul>
-					<AstNode value={ast} {path_nodes} {autoscroll} collapsed={false} />
+					<AstNode value={ast} {path_nodes} {autoscroll} root />
 				</ul>
 			{:else}
 				<p>No AST available</p>

--- a/packages/repl/src/lib/Output/AstView.svelte
+++ b/packages/repl/src/lib/Output/AstView.svelte
@@ -65,7 +65,7 @@
 		<code>
 			{#if typeof ast === 'object'}
 				<ul>
-					<AstNode value={ast} {path_nodes} {autoscroll} root />
+					<AstNode value={ast} {path_nodes} {autoscroll} />
 				</ul>
 			{:else}
 				<p>No AST available</p>


### PR DESCRIPTION
Before — bizarre layout, inaccessible to keyboard users, fugly arrows with wonky positioning, blank text for `undefined`, arrays that are expandable even if they have no children, small hit areas that move when items are toggled, weird use of underlining, hard to tell what's inside arrays without clicking into each item, just generally a bit of a clusterfuck

<img width="486" alt="image" src="https://github.com/user-attachments/assets/2d06ea1b-d13c-489f-964a-422ec7c1bc9c">

After — none of that. Just way more usable all round.

<img width="328" alt="image" src="https://github.com/user-attachments/assets/9c883b6a-d246-443a-bbd6-849f7d9d3f60">

I actually broke toggling in #692 — oops — and it renders the AST view effectively useless so I'm gonna go ahead and self-merge