### PR TITLE
Better search

### DIFF
--- a/apps/svelte.dev/src/routes/search/+page.server.js
+++ b/apps/svelte.dev/src/routes/search/+page.server.js
@@ -11,7 +11,7 @@ export async function load({ url, fetch }) {
 
 	const query = url.searchParams.get('q') ?? '';
 
-	const results = query ? search(query) : [];
+	const results = query ? search(query, '') : [];
 
 	return {
 		query,

--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -10,6 +10,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 	import Icon from '../components/Icon.svelte';
 	import SearchResults from './SearchResults.svelte';
 	import SearchWorker from './search-worker.js?worker';
+	import { page } from '$app/stores';
 
 	interface Props {
 		placeholder?: string;
@@ -94,7 +95,14 @@ It appears when the user clicks on the `Search` component or presses the corresp
 			const id = uid++;
 			pending.add(id);
 
-			worker.postMessage({ type: 'query', id, payload: $search_query });
+			worker.postMessage({
+				type: 'query',
+				id,
+				payload: {
+					query: $search_query,
+					path: $page.url.pathname
+				}
+			});
 		}
 	});
 

--- a/packages/site-kit/src/lib/search/search-worker.ts
+++ b/packages/site-kit/src/lib/search/search-worker.ts
@@ -12,8 +12,8 @@ addEventListener('message', async (event) => {
 	}
 
 	if (type === 'query') {
-		const query = payload;
-		const results = search(query);
+		const { query, path } = payload;
+		const results = search(query, path);
 
 		postMessage({ type: 'results', payload: { results, query } });
 	}

--- a/packages/site-kit/src/lib/search/types.d.ts
+++ b/packages/site-kit/src/lib/search/types.d.ts
@@ -8,5 +8,4 @@ export interface Block {
 export interface BlockGroup {
 	breadcrumbs: string[];
 	blocks: Block[];
-	score: number;
 }

--- a/packages/site-kit/src/lib/search/types.d.ts
+++ b/packages/site-kit/src/lib/search/types.d.ts
@@ -8,4 +8,5 @@ export interface Block {
 export interface BlockGroup {
 	breadcrumbs: string[];
 	blocks: Block[];
+	score: number;
 }


### PR DESCRIPTION
This implements a better search ranking algorithm. If you're on `/tutorial` and you search for, say, 'transitions', the top results will be from the tutorial. The same search if you're on `/docs` will prioritise docs results. But if you search for something that yields an exact title match, like `sv add`, then that will float to the top regardless of where you are.

The weights are magic numbers and there may be better ones, but these ones seem to work pretty well.