### PR TITLE
chore: spacing tweaks

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -380,11 +380,11 @@
 			li::before {
 				content: '';
 				position: absolute;
-				top: 1.1rem;
+				top: calc((var(--sk-font-size-body) / var(--sk-line-height-body)) - 0.05lh);
 				left: -1.8rem;
 				background-color: var(--sk-text-4);
-				width: 0.6rem;
-				height: 0.6rem;
+				width: 0.2lh;
+				height: 0.2lh;
 				border-radius: 50%;
 				opacity: 0.7;
 			}

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -119,6 +119,10 @@
 			margin: 2rem 0;
 			/* background: var(--sk-back-3); */
 
+			@media (min-width: 767px) {
+				margin: 3rem 0;
+			}
+
 			.controls {
 				--height: 3.6rem;
 				display: flex;
@@ -376,7 +380,7 @@
 			li::before {
 				content: '';
 				position: absolute;
-				top: 1.43rem;
+				top: 1.1rem;
 				left: -1.8rem;
 				background-color: var(--sk-text-4);
 				width: 0.6rem;

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -116,11 +116,11 @@
 			border: 1px solid var(--sk-back-5);
 			border-radius: var(--sk-border-radius);
 			overflow: hidden;
-			margin: 2rem 0;
+			margin: calc(0.5 * var(--sk-line-height-body)) 0;
 			/* background: var(--sk-back-3); */
 
 			@media (min-width: 767px) {
-				margin: 3rem 0;
+				margin: var(--sk-line-height-body) 0;
 			}
 
 			.controls {

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -380,11 +380,11 @@
 			li::before {
 				content: '';
 				position: absolute;
-				top: calc((var(--sk-font-size-body) / var(--sk-line-height-body)) - 0.05lh);
+				top: 0.65em;
 				left: -1.8rem;
 				background-color: var(--sk-text-4);
-				width: 0.2lh;
-				height: 0.2lh;
+				width: 0.3em;
+				height: 0.3em;
 				border-radius: 50%;
 				opacity: 0.7;
 			}

--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -136,13 +136,8 @@ header {
 /*	opinionated styles --------------------- */
 blockquote {
 	position: relative;
-	margin: 2.4rem 0;
-	padding: 2rem 2.4rem 1.8rem 2.4rem;
+	margin: var(--sk-line-height-body) 0;
 	max-width: var(--sk-page-content-width);
-
-	@media (min-width: 767px) {
-		margin: 4rem 0;
-	}
 }
 
 blockquote :where(p, ul, ol) {

--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -56,15 +56,6 @@ ol {
 	}
 }
 
-ul,
-ol {
-	margin-top: 1rem;
-}
-
-p:has(+ ul, + ol) {
-	margin-bottom: 1rem;
-}
-
 a {
 	position: relative;
 	text-decoration: none;

--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -45,7 +45,7 @@ p,
 ul,
 ol {
 	font: var(--sk-font-body);
-	margin: 2rem 0;
+	margin: 0.5lh 0;
 
 	&:first-child {
 		margin-top: 0;

--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -45,7 +45,7 @@ p,
 ul,
 ol {
 	font: var(--sk-font-body);
-	margin: 1lh 0;
+	margin: 2rem 0;
 
 	&:first-child {
 		margin-top: 0;
@@ -54,6 +54,15 @@ ol {
 	&:last-child {
 		margin-bottom: 0;
 	}
+}
+
+ul,
+ol {
+	margin-top: 1rem;
+}
+
+p:has(+ ul, + ol) {
+	margin-bottom: 1rem;
 }
 
 a {
@@ -139,6 +148,10 @@ blockquote {
 	margin: 2.4rem 0;
 	padding: 2rem 2.4rem 1.8rem 2.4rem;
 	max-width: var(--sk-page-content-width);
+
+	@media (min-width: 767px) {
+		margin: 4rem 0;
+	}
 }
 
 blockquote :where(p, ul, ol) {

--- a/packages/site-kit/src/lib/styles/tokens.css
+++ b/packages/site-kit/src/lib/styles/tokens.css
@@ -39,7 +39,9 @@
 	--sk-font-size-ui-large: 3rem;
 	--sk-font-size-mono: 1.4rem;
 
-	--sk-line-height-body: 1.5;
+	/* doing it this way (rather than just `1.5`) means it has a unit, and can be used elsewhere */
+	--sk-line-height-body: calc(1.5 * var(--sk-font-size-body));
+	--sk-line-height-body-small: calc(1.5 * var(--sk-font-size-body-small));
 
 	--sk-font-h1: 500 var(--sk-font-size-h1) / 1.2 var(--sk-font-family-heading);
 	--sk-font-h2: 500 var(--sk-font-size-h2) / 1.2 var(--sk-font-family-heading);


### PR DESCRIPTION
- make paragraph breaks less spacey
- move `ul` closer to the preceeding paragraph which gives more visual clarity of where it belongs to
- give code blocks a bit more space at the top/bottom on larger screens
- give blockquotes more space at the top/bottom on larger screens

Combined, these changes give more visual clarity of which things belong together, which stand on its own, etc
