### PR TITLE
reduce paragraph margin

### DIFF
--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -45,7 +45,7 @@ p,
 ul,
 ol {
 	font: var(--sk-font-body);
-	margin: 1lh 0;
+	margin: 0.5lh 0;
 
 	&:first-child {
 		margin-top: 0;


### PR DESCRIPTION
We previously bumped the paragraph margin to `1lh` (#541), but having sat with it a while I think that was a mistake. We've had feedback — which I agree with — that the relationship between headings and copy is unclear. It also results in lower-than-ideal information density.

While `1lh` is considered something of a 'rule' in typography, I do think this works better in basically all cases (old on the left, new on the right):

<img width="1937" alt="image" src="https://github.com/user-attachments/assets/fb437762-78ad-4e07-b3c5-5a47144d2739">

<img width="1940" alt="image" src="https://github.com/user-attachments/assets/b5b38767-9927-463e-ab00-6d693fc9fb2c">

<img width="1939" alt="image" src="https://github.com/user-attachments/assets/ff72aeb0-1308-4a73-8695-bb414be4b2b6">

<img width="1938" alt="image" src="https://github.com/user-attachments/assets/f2b2651c-fb25-4564-81f7-9c1ff6170d3c">

<img width="1936" alt="image" src="https://github.com/user-attachments/assets/24244029-4f33-49b9-ad26-a3910c9e8eb5">
