### PR TITLE
chore: light background for code snippets

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -112,12 +112,15 @@
 
 		.code-block {
 			position: relative;
-			background: var(--sk-back-2);
+			background: var(--sk-back-3);
 			border: 1px solid var(--sk-back-5);
 			border-radius: var(--sk-border-radius);
 			overflow: hidden;
 			margin: calc(0.5 * var(--sk-line-height-body)) 0;
-			/* background: var(--sk-back-3); */
+
+			.dark & {
+				background: var(--sk-back-2);
+			}
 
 			@media (min-width: 767px) {
 				margin: var(--sk-line-height-body) 0;
@@ -139,8 +142,14 @@
 
 				&:has(.filename) {
 					position: relative;
-					background: var(--sk-back-3);
+					background: var(--sk-back-4);
 					padding-left: 1rem;
+				}
+
+				.dark & {
+					&:has(.filename) {
+						background: var(--sk-back-3);
+					}
 				}
 
 				&:not(:has(.filename)) {


### PR DESCRIPTION
While working on tweaking dark mode I noticed that I find the content much easier to scan. Turns out it's because we don't give code blocks any background whatsoever, which in my view is a mistake. It makes the code too easy to mix up with the surrounding text when scrolling and searching for something.

This gives the code blocks a very very light grey background, which in my opinion achieves a sweet spot between making it easier to separate code from text while not getting in the way. (The fact that there was a commented-out `--sk-back-3` makes me believe this was actually something on the todo list or something that was contemplated to do)