### PR TITLE
fix #320

### DIFF
--- a/packages/editor/src/lib/Editor.svelte
+++ b/packages/editor/src/lib/Editor.svelte
@@ -52,14 +52,25 @@
 	}}
 />
 
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	class="container"
 	bind:this={container}
-	onfocusin={() => {
+	onpointerdown={() => {
+		workspace.enable_tab_indent();
+	}}
+	onkeydown={(e) => {
+		if (e.key !== 'Tab') {
+			workspace.enable_tab_indent();
+		}
+	}}
+	onfocusin={(e) => {
 		clearTimeout(remove_focus_timeout);
 		preserve_editor_focus = true;
 	}}
 	onfocusout={() => {
+		workspace.disable_tab_indent();
+
 		// Heuristic: user did refocus themmselves if iframe_took_focus
 		// doesn't happen in the next few miliseconds. Needed
 		// because else navigations inside the iframe refocus the editor.


### PR DESCRIPTION
fixes #320 — if you click into an editor, or type while it's focused, the tab key will then indent stuff. But if you tab into it and press again, the tab key will _not_ indent stuff — instead, focus travels to the next focusable element.

This means we meet the no-keyboard-trap requirement of WCAG 2.1 https://www.w3.org/TR/WCAG21/#no-keyboard-trap