### PR TITLE
docs: Update index.md for Tutorial: Advanced Svelte / Advanced reactivity / Raw state

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/01-advanced-reactivity/01-raw-state/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/01-advanced-reactivity/01-raw-state/index.md
@@ -4,7 +4,7 @@ title: Raw state
 
 In previous exercises, we learned that state is [deeply reactive](deep-state) — if you (for example) change a property of an object, or push to an array, it will cause the UI to update. This works by creating a [proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) that intercepts reads and writes.
 
-Occasionally, that's not what you want. If you're not changing individual properties, or if it's important to main referential equality, then you can use _raw state_ instead.
+Occasionally, that's not what you want. If you're not changing individual properties, or if it's important to maintain referential equality, then you can use _raw state_ instead.
 
 In this example, we have a chart of Svelte's steadily increasing stock price. We want the chart to update when new data comes in, which we could achieve by turning `data` into state...
 


### PR DESCRIPTION
Fixed a minor typo:
Old Statement - "...it's important to main referential equality..."
Fixed Statement - "...it's important to maintain referential equality..."
Tutorial [Link](https://svelte.dev/tutorial/svelte/raw-state)

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
