### PR TITLE
add --pull flag to sync-docs, pull existing repo if nec

### DIFF
--- a/apps/svelte.dev/scripts/sync-docs/index.ts
+++ b/apps/svelte.dev/scripts/sync-docs/index.ts
@@ -128,7 +128,7 @@ const packages: Package[] = [
 	{
 		name: 'cli',
 		repo: 'sveltejs/cli',
-		branch: 'chore/add-docs',
+		branch: 'main',
 		pkg: 'packages/cli',
 		docs: 'documentation/docs',
 		types: null
@@ -199,4 +199,6 @@ if (parsed.values.watch) {
 				sync(pkg);
 			});
 	}
+
+	console.log(`\nwatching for changes in ${parsed.positionals.join(', ')}`);
 }

--- a/apps/svelte.dev/scripts/sync-docs/utils.ts
+++ b/apps/svelte.dev/scripts/sync-docs/utils.ts
@@ -1,17 +1,21 @@
-import { spawn, type SpawnOptions } from 'node:child_process';
+import { execSync, spawn, type SpawnOptions } from 'node:child_process';
 import fs from 'node:fs';
 import glob from 'tiny-glob/sync';
 
-export async function clone_repo(repo: string, branch: string, cwd: string) {
-	const regex_result = /https:\/\/github.com\/\w+\/(\w+).git/.exec(repo);
-	if (!regex_result || regex_result.length < 2) {
-		throw new Error(`Expected https://github.com/xxx/xxx.git, but got ${repo}`);
-	}
+export async function clone_repo(repo: string, name: string, branch: string, cwd: string) {
+	const dir = `${cwd}/${name}`;
 
-	const dirname = `${cwd}/${regex_result[1]}`;
-	if (fs.existsSync(dirname)) {
-		// TODO skip if we detect that same branch is already cloned
-		fs.rmSync(dirname, { recursive: true });
+	if (fs.existsSync(dir)) {
+		const opts = { cwd: dir };
+
+		if (execSync('git status -s', opts).toString() !== '') {
+			throw new Error(`${name} repo is dirty — aborting`);
+		}
+
+		await invoke('git', ['checkout', branch], opts);
+		await invoke('git', ['pull'], opts);
+
+		return;
 	}
 
 	await invoke('git', ['clone', '--depth', '1', '--branch', branch, repo], {
@@ -22,14 +26,15 @@ export async function clone_repo(repo: string, branch: string, cwd: string) {
 export function invoke(cmd: string, args: string[], opts: SpawnOptions) {
 	const child = spawn(cmd, args, { ...opts, stdio: 'inherit' });
 
-	return new Promise<void>((resolve) => {
+	return new Promise<void>((fulfil, reject) => {
 		child.on('close', (code) => {
-			if (!code) {
-				console.log(`${[cmd, ...args].join(' ')} successfully completed`);
+			if (code) {
+				reject(new Error(`Exited with code ${code}`));
+				return;
 			}
 
 			// Give it some extra time to finish writing files to disk
-			setTimeout(() => resolve(), 500);
+			setTimeout(fulfil, 500);
 		});
 	});
 }


### PR DESCRIPTION
This improves the sync script a bit — it allows you to specify a `-p` or `--pull` flag which pulls from the remote (or clones the repo if necessary), and also specify which packages we care about:

```bash
pnpm sync-docs          # sync everything
pnpm sync-docs -w       # sync everything and watch for changes

pnpm sync-docs cli      # just sync `cli` docs
pnpm sync-docs cli kit  # sync `cli` and `kit` docs

pnpm sync-docs -pw kit  # pull or clone `kit` docs, sync, and watch for changes
```

This is groundwork for setting up an automated workflow