### PR TITLE
add sync-docs workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,30 @@
+name: Sync docs
+
+on:
+  # Listen to a repository dispatch event by the name of `dispatch-event`
+  repository_dispatch:
+    types: [sync-request]
+
+jobs:
+  log:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Sync
+        run: cd apps/svelte.dev && pnpm sync-docs -p ${{ github.event.client_payload.package }}
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: sync ${{ github.event.client_payload.package }} docs
+          title: Sync ${{ github.event.client_payload.package }}
+          body: This is an automated pull request
+          branch: sync:${{ github.event.client_payload.package }}
+          base: main

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,7 +1,6 @@
 name: Sync docs
 
 on:
-  # Listen to a repository dispatch event by the name of `dispatch-event`
   repository_dispatch:
     types: [sync-request]
 


### PR DESCRIPTION
This is not my wheelhouse, so it'll probably take some fiddling to get right, BUT

If it works then we will be able to add corresponding workflows in the source repos that create/update PRs in this repo so that we don't need to manually sync docs any more. Only way we can actually test this is by merging it, so that's what I'll do