### PR TITLE
fix: show compiler message for older Svelte versions

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -609,7 +609,7 @@ async function bundle({
 			server: null,
 			imports: null,
 			warnings: client.warnings,
-			error: { ...e }
+			error: { ...e, message: e.message } // not all Svelte versions return an enumerable message property
 		};
 	}
 }


### PR DESCRIPTION
Older Svelte versions did extend their compiler error from Error without marking the message property as enumerable. Therefore we need to explicitly add it to the destructuring.
