### PR TITLE
chore: warn instead of error when no linked repo found

### DIFF
--- a/apps/svelte.dev/scripts/sync-docs/index.ts
+++ b/apps/svelte.dev/scripts/sync-docs/index.ts
@@ -167,6 +167,11 @@ if (parsed.values.pull) {
 }
 
 async function sync(pkg: Package) {
+	if (!fs.existsSync(`${REPOS}/${pkg.name}/${pkg.docs}`)) {
+		console.warn(`No linked repo found for ${pkg.name}`);
+		return;
+	}
+
 	const dest = `${DOCS}/${pkg.name}`;
 
 	fs.rmSync(dest, { force: true, recursive: true });


### PR DESCRIPTION
Not everyone might be interested in having all repos locally linked up, and only care about locally syncing/updating specific repos at a time. That's currently not possible because the sync script error with a somewhat hard to understand error, because it can't find a certain repo. This adds a dedicated check and shows a warning instead of erroring.
