### PR TITLE
create docs-preview-create workflow

### DIFF
--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -16,12 +16,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      - name: Sync
-        run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ github.event.client_payload.owner }}" -p "${{ github.event.client_payload.package }}#${{ github.event.client_payload.branch }}""
+      - name: Checkout
+        run: git checkout -B refs/heads/sync/${{ github.event.client_payload.package }}/${{ github.event.client_payload.owner }}/${{ github.event.client_payload.branch }}
 
-      - name: Create branch
-        uses: peterjgrainger/action-create-branch@v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          branch: refs/heads/sync/${{ github.event.client_payload.package }}/${{ github.event.client_payload.owner }}/${{ github.event.client_payload.branch }}
+      - name: Sync
+        run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ github.event.client_payload.owner }}" -p "${{ github.event.client_payload.package }}#${{ github.event.client_payload.branch }}"
+
+      - name: Push
+        run: git add -A && git commit -m "sync docs" && git push -u origin sync/${{ github.event.client_payload.package }}/${{ github.event.client_payload.owner }}/${{ github.event.client_payload.branch }}

--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -1,0 +1,27 @@
+name: Docs preview create
+
+on:
+  repository_dispatch:
+    types: [docs-preview-create]
+
+jobs:
+  Sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Sync
+        run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ github.event.client_payload.owner }}" -p "${{ github.event.client_payload.package }}#${{ github.event.client_payload.branch }}""
+
+      - name: Create branch
+        uses: peterjgrainger/action-create-branch@v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: refs/heads/sync/${{ github.event.client_payload.package }}/${{ github.event.client_payload.owner }}/${{ github.event.client_payload.branch }}

--- a/apps/svelte.dev/scripts/sync-docs/utils.ts
+++ b/apps/svelte.dev/scripts/sync-docs/utils.ts
@@ -8,6 +8,10 @@ export async function clone_repo(repo: string, name: string, branch: string, cwd
 	if (fs.existsSync(dir)) {
 		const opts = { cwd: dir };
 
+		if (!repo.startsWith('sveltejs/')) {
+			console.warn('Ignoring --owner flag for already-cloned repo');
+		}
+
 		if (execSync('git status -s', opts).toString() !== '') {
 			throw new Error(`${name} repo is dirty — aborting`);
 		}


### PR DESCRIPTION
step one of #59 — create a new workflow that runs on a `docs-preview-create` repository dispatch. The idea is that every push to a PR on `svelte` or `kit` or `cli` will cause a preview branch to be created.

TODO

- [ ] see if this actually works (need to merge it to find out; will probably need to mess around with PATs in order to create and push branches, not sure if the provided token has those permissions)
- [ ] set up workflows on the other repos
- [ ] figure out how to add a comment on the PR with a link to the preview deployment (but only if docs were affected)
- [ ] set up a workflow to delete the branch when the PR is closed/merged