### PR TITLE
fix: ensure correct options for Svelte 3/4

### DIFF
--- a/packages/editor/src/lib/compile-worker/worker.ts
+++ b/packages/editor/src/lib/compile-worker/worker.ts
@@ -71,12 +71,20 @@ addEventListener('message', async (event) => {
 		let result: CompileResult;
 
 		if (file.name.endsWith('.svelte')) {
-			result = self.svelte.compile(file.contents, {
-				generate: options.generate, // TODO do we need to adjust this for 3/4?
+			const is_svelte_3_or_4 = !self.svelte.compileModule;
+			const compilerOptions: any = {
+				generate: is_svelte_3_or_4
+					? options.generate === 'client'
+						? 'dom'
+						: 'ssr'
+					: options.generate,
 				dev: options.dev,
-				modernAst: options.modernAst,
 				filename: file.name
-			});
+			};
+			if (!is_svelte_3_or_4) {
+				compilerOptions.modernAst = options.modernAst; // else Svelte 3/4 will throw an "unknown option" error
+			}
+			result = self.svelte.compile(file.contents, compilerOptions);
 		} else {
 			result = self.svelte.compileModule(file.contents, {
 				generate: options.generate,


### PR DESCRIPTION
- pass dom/ssr instead of client/server for `generate`
- don't pass `modernAst`, will crash the whole view with an "unknown option" error
