### PR TITLE
chore: print correct packages in `watching for changes` message

### DIFF
--- a/apps/svelte.dev/scripts/sync-docs/index.ts
+++ b/apps/svelte.dev/scripts/sync-docs/index.ts
@@ -219,5 +219,5 @@ if (parsed.values.watch) {
 			});
 	}
 
-	console.log(`\nwatching for changes in ${parsed.positionals.join(', ')}`);
+	console.log(`\nwatching for changes in ${filtered.map((pkg) => pkg.name).join(', ')}`);
 }


### PR DESCRIPTION
Running `pnpm sync-docs -w` resulted in the message `watching for changes in` being printed, without displaying the names of the packages it was actually watching

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
