### PR TITLE
feat: Add support for iOS safe area

### DIFF
--- a/packages/site-kit/src/app.html
+++ b/packages/site-kit/src/app.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
 		%sveltekit.head%
 	</head>

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -311,6 +311,8 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		nav {
 			top: unset;
 			bottom: 0;
+			padding-bottom: env(safe-area-inset-bottom);
+			height: calc(var(--sk-nav-height) + env(safe-area-inset-bottom));
 		}
 
 		.menu {

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -311,8 +311,11 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		nav {
 			top: unset;
 			bottom: 0;
-			padding-bottom: env(safe-area-inset-bottom);
-			height: calc(var(--sk-nav-height) + env(safe-area-inset-bottom));
+
+			&.visible, &:focus-within {
+				padding-bottom: env(safe-area-inset-bottom);
+				height: calc(var(--sk-nav-height) + env(safe-area-inset-bottom));
+			}
 		}
 
 		.menu {


### PR DESCRIPTION
Add support for iOS' safe area environment variables to prevent the navbar from being hidden behind the iPhone's home bar.

It works using the [official layout guide](https://webkit.org/blog/7929/designing-websites-for-iphone-x/), which was originally made after the introduction of the iPhone X with iOS 11.  
It exposes the `env()` CSS function with 4 variables (`safe-area-inset-{top,left,right,bottom}`), requiring `viewport-fit=cover` in the `viewport` meta tag to get rid of natural viewport margins.

These environment variables are smartly populated by the system based on the current Safari layout, giving them a value granularly as needed.

> [!NOTE]
> You might note my PR doesn't include the outdated `constant()` function, the previous name of `env()` between iOS 11.0 and 11.2 beta versions: the already low range of concerned versions combined with the ancient age of this major iOS version isn’t worth the effort, in my opinion.
> It can, however, be easily added at will with `@supports` queries or CSS rules fallbacks after bypassing `calc()` calls.

On desktop, the `env()` function is ([supposedly](https://stackoverflow.com/questions/47302707/css-safe-area-attributes-doesnt-work-on-iphone-x#:~:text=Firstly%2C%20safe%2Darea%2Dinset%2Ddir%20is%20undefined%20on%20Chrome%20and%20Safari%20on%20mac)) undefined, invalidating the CSS lines using it, leading to no repercussions on desktop browsers or other mobile browsers. I've tested it on Arc / Chrome desktop in responsive mode and noticed no impact.

## Demo

| <img src="https://github.com/user-attachments/assets/287d8280-eef8-4f34-a1f6-06e94a06f818" alt="before" width="400" /> | <img src="https://github.com/user-attachments/assets/114cfbb3-f292-4036-982a-f67b619a0040" alt="after" width="400" /> |
| :---: | :---: |
| **Before** _(old Safari layout/in-app browser)_ | **After** _(old Safari layout/in-app browser)_ |

| <img src="https://github.com/user-attachments/assets/5a6191bb-0eb6-4979-9078-68429a99a366" alt="after old UI regular" width="400" /> | <img src="https://github.com/user-attachments/assets/5b3849f5-d969-42a1-b608-422c8f36b262" alt="after new UI" width="400" /> |
| :---: | :---: |
| **After** _(old Safari layout/in-app browser - "unscrolled" state)_ | **After** _(new Safari layout - not impacted)_ |

---

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
