### PR TITLE
docs(snippets-and-render-tags): Replace hard coded text

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/02-snippets/01-snippets-and-render-tags/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/02-snippets/01-snippets-and-render-tags/index.md
@@ -15,7 +15,7 @@ Begin by _declaring a snippet_:
 +++{#snippet monkey()}+++
 	<tr>
 		<td>{emoji}</td>
-		<td>see no evil</td>
+		<td>{description}</td>
 		<td>\u{emoji.charCodeAt(0).toString(16)}\u{emoji.charCodeAt(1).toString(16)}</td>
 		<td>&amp#{emoji.codePointAt(0)}</td>
 	</tr>


### PR DESCRIPTION
Replace hard coded text "see no evil" with `{description}` in `monkey` snippet so that it is inline with the solution.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
Did not feel like a big enough change that needed an issue, however I can create one if required 🙂
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
