### PR TITLE
fix: mobile nav links to SvelteKit tutorials

### DIFF
--- a/apps/svelte.dev/src/routes/+layout.server.ts
+++ b/apps/svelte.dev/src/routes/+layout.server.ts
@@ -28,7 +28,11 @@ const nav_links: NavigationLink[] = [
 				title: section.metadata.title,
 				sections: section.children.map((page) => ({
 					title: page.metadata.title,
-					path: '/tutorial/' + page.slug.split('/').pop()
+					path:
+						'/tutorial/' +
+						(page.slug.includes('sveltekit/') ? 'kit' : 'svelte') +
+						'/' +
+						page.slug.split('/').pop()
 				}))
 			}))
 		}))


### PR DESCRIPTION
### A note on documentation PRs

Fixes #829. Pointing the link to the right place seemed like the correct way to address this, not fixing the redirects.

This solution feels really ugly, but I don't know how else to deal with this. The metadata that's exposed from the pages seems like it would have to change if we don't want to be looking for substrings in slugs like this. I do note that `apps/svelte.dev/src/routes/tutorial/[...slug]/content.server.ts` is already doing something similar with looking at the slug strings.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
