### PR TITLE
docs: Fix Typo in advanced tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/01-advanced-reactivity/01-raw-state/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/01-advanced-reactivity/01-raw-state/index.md
@@ -4,7 +4,7 @@ title: Raw state
 
 In previous exercises, we learned that state is [deeply reactive](deep-state) — if you (for example) change a property of an object, or push to an array, it will cause the UI to update. This works by creating a [proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) that intercepts reads and writes.
 
-Occasionally, that's not what you want. If you're not changing individual properties, or if it's important to main referential equality, then you can use _raw state_ instead.
+Occasionally, that's not what you want. If you're not changing individual properties, or if it's important to maintain referential equality, then you can use _raw state_ instead.
 
 In this example, we have a chart of Svelte's steadily increasing stock price. We want the chart to update when new data comes in, which we could achieve by turning `data` into state...
 


### PR DESCRIPTION
Fixed a Typo in 01-advanced-reactivity 01-raw-state.

I am not sure if this belongs in this repo or in sveltejs/svelte, but I couldn't find the advanced tutorial in there. 