### PR TITLE
fix: move cursor pointer style on panel header to the clickable part

### DIFF
--- a/packages/repl/src/lib/Output/PaneWithPanel.svelte
+++ b/packages/repl/src/lib/Output/PaneWithPanel.svelte
@@ -61,7 +61,6 @@
 		justify-content: space-between;
 		align-items: center;
 		padding: 0.5rem 0.5rem 0.5rem 1rem;
-		cursor: pointer;
 	}
 
 	.panel-body {
@@ -73,6 +72,7 @@
 		text-transform: uppercase;
 		flex: 1;
 		text-align: left;
+		cursor: pointer;
 	}
 
 	section {


### PR DESCRIPTION
edit: closing due to inactivity

The playground console header's toggle button has no `cursor: pointer` but its noninteractive wrapper div does, this moves the style to the button. The current behavior makes the non-clickable part appear clickable and the button not.

An alternative would be to just delete `cursor: pointer;` if that was the desired aesthetic but it would be less clear on desktop what's clickable. I think a small improvement, that also makes just deleting the line better, would be to move the `.panel-header` wrapper's padding to be a child concern, allowing the `.panel-heading` button to have `height: 100%` to fill its container.

I tried the padding change but the component is used in two places and slotted sibling styles are a bit tricky to get right, and I couldn't test the other place because Firefox/Chromium on Linux are erroring with `SvelteKitError: Not found: /node_modules/.vite/deps/bindings_wasm_bg.wasm` and in the browser `CompileError: WebAssembly.instantiate(): expected magic word ...`, I think related to this Vite issue - https://github.com/vitejs/vite/issues/8427

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
