### PR TITLE
fix: repl example '<svelte:document>'

### DIFF
--- a/apps/svelte.dev/content/examples/17-special-elements/04-svelte-document/+assets/App.svelte
+++ b/apps/svelte.dev/content/examples/17-special-elements/04-svelte-document/+assets/App.svelte
@@ -1,7 +1,7 @@
 <script>
 	let selection = $state('');
 
-	const handleSelectionChange = (e) => (selection = document.getSelection());
+	const handleSelectionChange = (e) => (selection = document.getSelection().toString());
 </script>
 
 <svelte:document onselectionchange={handleSelectionChange} />


### PR DESCRIPTION
Svelte Repl isn't working without `.toString()` on the selection.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
