### PR TITLE
fix: resolve `module` and `browser` conditions for fetched packages in REPL

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -176,7 +176,7 @@ async function resolve_from_pkg(
 		try {
 			const resolved = resolve.exports(pkg, subpath, {
 				browser: true,
-				conditions: ['svelte', 'development']
+				conditions: ['svelte', 'module', 'browser', 'development']
 			});
 
 			return resolved?.[0];


### PR DESCRIPTION
I believe both of those should be added here:
- `module` is meant to help avoid dual package hazards because it allows both `require` and `import` to resolve to it and instantiate only a single instance of the package. Even though REPL is not a bundler, I don't see why this would not be something that you'd like to support here. It's legit for `import` to point to an `.mjs` wrapper for the CJS content and this field can be used to point resolvers directly to ESM bundles
- `browser` - you already configure `browser: true` but, according to the docs, that just enables support for the browser **field** (`package.json#browser`). The proposed change should also add it to supported `exports` conditions

---

I verified manually that it fixes this REPL code:
```svelte
<script>
	import {setup} from "xstate"
	let name = setup({}).createMachine({ context: { name: 'world!' } }).getInitialSnapshot().context.name;
</script>

<h1>Hello {name}!</h1>
```
