### PR TITLE
fix: update all $state.frozen autocomplete sugestions to $state.raw

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/03-props/03-spread-props/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/03-props/03-spread-props/index.md
@@ -38,5 +38,5 @@ We _could_ fix it by adding the prop...
 > ...in which case you can access the properties by their object paths:
 >
 > ```js
-> console.log(stuff.name, stuff.version, stuff.description, stuff.website)
+> console.log(stuff.name, stuff.version, stuff.description, stuff.website);
 > ```

--- a/packages/site-kit/src/lib/codemirror/autocompletionDataProvider.js
+++ b/packages/site-kit/src/lib/codemirror/autocompletionDataProvider.js
@@ -493,7 +493,7 @@ const is_state = (node) => {
 
 /**
  * Returns `true` if we're already in a valid call expression, e.g.
- * changing an existing `$state()` to `$state.frozen()`
+ * changing an existing `$state()` to `$state.raw()`
  * @type {import("./types").Test}
  */
 const is_state_call = (node) => {
@@ -583,8 +583,8 @@ export const runes = [
 	{ snippet: '$derived.by', test: is_state_call },
 	{ snippet: '$effect(() => {\n\t${}\n});', test: is_statement },
 	{ snippet: '$effect.pre(() => {\n\t${}\n});', test: is_statement },
-	{ snippet: '$state.frozen(${});', test: is_state },
-	{ snippet: '$state.frozen', test: is_state_call },
+	{ snippet: '$state.raw(${});', test: is_state },
+	{ snippet: '$state.raw', test: is_state_call },
 	{ snippet: '$bindable()', test: is_bindable },
 	{ snippet: '$effect.root(() => {\n\t${}\n})' },
 	{ snippet: '$state.snapshot(${})' },


### PR DESCRIPTION
The playground suggested using the $state.frozen rune, which was removed, but not $state.raw, its replacement.
This PR fixes that.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
