### PR TITLE
fix: state_proxy_equality_mismatch error in deferred-transitions example

### DIFF
--- a/apps/svelte.dev/content/examples/09-transitions/06-deferred-transitions/+assets/App.svelte
+++ b/apps/svelte.dev/content/examples/09-transitions/06-deferred-transitions/+assets/App.svelte
@@ -7,8 +7,8 @@
 		fallback: scale
 	});
 
-	let selected = $state(null);
-	let loading = $state(null);
+	let selected = $state.raw(null);
+	let loading = $state.raw(null);
 
 	const ASSETS = `https://sveltejs.github.io/assets/crossfade`;
 


### PR DESCRIPTION
The deferred-transitions example was doing "===" comparison with a proxy, this pr fixes that by using $state.raw instead of $state

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
