### PR TITLE
fix: incorrect value in <select> element.

### DIFF
--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/Controls.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/Controls.svelte
@@ -17,7 +17,7 @@
 	// TODO this really sucks, why is `exercise.slug` not the slug?
 	let actual_slug = $derived.by(() => {
 		const parts = exercise.slug.split('/');
-		return `${parts[1]}/${parts[3]}`;
+		return `${parts[1].includes('kit') ? 'kit' : 'svelte'}/${parts[3]}`;
 	});
 </script>
 


### PR DESCRIPTION
## Fix incorrect value in Select element #447 

### Description
The `actual_slug` computation in `Controls.svelte` was incorrectly handling the slug format, which led to incorrect values being set in the `<select>` element.

### Changes
- Modified the logic in line 20 to correctly determine the `actual_slug` based on whether "kit" is present in `parts[1]`.
- Updated the computation to use `parts[1].includes('kit') ? 'kit' : 'svelte'` to ensure the correct slug format.
