### PR TITLE
include classes in exports

### DIFF
--- a/apps/svelte.dev/content/docs/kit/98-reference/10-@sveltejs-kit.md
+++ b/apps/svelte.dev/content/docs/kit/98-reference/10-@sveltejs-kit.md
@@ -7,6 +7,7 @@ title: @sveltejs/kit
 ```js
 // @noErrors
 import {
+	Server,
 	VERSION,
 	error,
 	fail,
@@ -18,6 +19,43 @@ import {
 	text
 } from '@sveltejs/kit';
 ```
+
+## Server
+
+<div class="ts-block">
+
+```dts
+class Server {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+constructor(manifest: SSRManifest);
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+init(options: ServerInitOptions): Promise<void>;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+respond(request: Request, options: RequestOptions): Promise<Response>;
+```
+
+<div class="ts-block-property-details"></div>
+</div></div>
+
+
 
 ## VERSION
 
@@ -94,7 +132,9 @@ Checks whether this is an action failure thrown by `fail`.
 <div class="ts-block">
 
 ```dts
-function isActionFailure(e: unknown): e is ActionFailure;
+function isActionFailure(
+	e: unknown
+): e is ActionFailure<undefined>;
 ```
 
 </div>
@@ -2301,41 +2341,6 @@ A `[file]: size` map of all assets imported by server code
 </div></div>
 
 </div>
-</div></div>
-
-## Server
-
-<div class="ts-block">
-
-```dts
-class Server {/*…*/}
-```
-
-<div class="ts-block-property">
-
-```dts
-constructor(manifest: SSRManifest);
-```
-
-<div class="ts-block-property-details"></div>
-</div>
-
-<div class="ts-block-property">
-
-```dts
-init(options: ServerInitOptions): Promise<void>;
-```
-
-<div class="ts-block-property-details"></div>
-</div>
-
-<div class="ts-block-property">
-
-```dts
-respond(request: Request, options: RequestOptions): Promise<Response>;
-```
-
-<div class="ts-block-property-details"></div>
 </div></div>
 
 ## ServerInitOptions

--- a/apps/svelte.dev/content/docs/svelte/98-reference/20-svelte.md
+++ b/apps/svelte.dev/content/docs/svelte/98-reference/20-svelte.md
@@ -7,6 +7,8 @@ title: svelte
 ```js
 // @noErrors
 import {
+	SvelteComponent,
+	SvelteComponentTyped,
 	afterUpdate,
 	beforeUpdate,
 	createEventDispatcher,
@@ -25,6 +27,148 @@ import {
 	untrack
 } from 'svelte';
 ```
+
+## SvelteComponent
+
+This was the base class for Svelte components in Svelte 4. Svelte 5+ components
+are completely different under the hood. For typing, use `Component` instead.
+To instantiate components, use `mount` instead`.
+See [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-longer-classes) for more info.
+
+<div class="ts-block">
+
+```dts
+class SvelteComponent<
+	Props extends Record<string, any> = Record<string, any>,
+	Events extends Record<string, any> = any,
+	Slots extends Record<string, any> = any
+> {/*…*/}
+```
+
+<div class="ts-block-property">
+
+```dts
+static element?: typeof HTMLElement;
+```
+
+<div class="ts-block-property-details">
+
+The custom element version of the component. Only present if compiled with the `customElement` compiler option
+
+</div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+[prop: string]: any;
+```
+
+<div class="ts-block-property-details"></div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+constructor(options: ComponentConstructorOptions<Properties<Props, Slots>>);
+```
+
+<div class="ts-block-property-details">
+
+<div class="ts-block-property-bullets">
+
+- <span class="tag deprecated">deprecated</span> This constructor only exists when using the `asClassComponent` compatibility helper, which
+is a stop-gap solution. Migrate towards using `mount` instead. See
+https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes for more info.
+
+</div>
+
+</div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+$destroy(): void;
+```
+
+<div class="ts-block-property-details">
+
+<div class="ts-block-property-bullets">
+
+- <span class="tag deprecated">deprecated</span> This method only exists when using one of the legacy compatibility helpers, which
+is a stop-gap solution. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes
+for more info.
+
+</div>
+
+</div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+$on<K extends Extract<keyof Events, string>>(
+	type: K,
+	callback: (e: Events[K]) => void
+): () => void;
+```
+
+<div class="ts-block-property-details">
+
+<div class="ts-block-property-bullets">
+
+- <span class="tag deprecated">deprecated</span> This method only exists when using one of the legacy compatibility helpers, which
+is a stop-gap solution. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes
+for more info.
+
+</div>
+
+</div>
+</div>
+
+<div class="ts-block-property">
+
+```dts
+$set(props: Partial<Props>): void;
+```
+
+<div class="ts-block-property-details">
+
+<div class="ts-block-property-bullets">
+
+- <span class="tag deprecated">deprecated</span> This method only exists when using one of the legacy compatibility helpers, which
+is a stop-gap solution. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes
+for more info.
+
+</div>
+
+</div>
+</div></div>
+
+
+
+## SvelteComponentTyped
+
+<blockquote class="tag deprecated">
+
+Use `Component` instead. See [migration guide](https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes) for more information.
+
+</blockquote>
+
+<div class="ts-block">
+
+```dts
+class SvelteComponentTyped<
+	Props extends Record<string, any> = Record<string, any>,
+	Events extends Record<string, any> = any,
+	Slots extends Record<string, any> = any
+> extends SvelteComponent<Props, Events, Slots> {}
+```
+
+</div>
+
+
 
 ## afterUpdate
 
@@ -757,143 +901,5 @@ interface Snippet<Parameters extends unknown[] = []> {/*…*/}
 
 <div class="ts-block-property-details"></div>
 </div></div>
-
-## SvelteComponent
-
-This was the base class for Svelte components in Svelte 4. Svelte 5+ components
-are completely different under the hood. For typing, use `Component` instead.
-To instantiate components, use `mount` instead`.
-See [migration guide](/docs/svelte/v5-migration-guide#Components-are-no-longer-classes) for more info.
-
-<div class="ts-block">
-
-```dts
-class SvelteComponent<
-	Props extends Record<string, any> = Record<string, any>,
-	Events extends Record<string, any> = any,
-	Slots extends Record<string, any> = any
-> {/*…*/}
-```
-
-<div class="ts-block-property">
-
-```dts
-static element?: typeof HTMLElement;
-```
-
-<div class="ts-block-property-details">
-
-The custom element version of the component. Only present if compiled with the `customElement` compiler option
-
-</div>
-</div>
-
-<div class="ts-block-property">
-
-```dts
-[prop: string]: any;
-```
-
-<div class="ts-block-property-details"></div>
-</div>
-
-<div class="ts-block-property">
-
-```dts
-constructor(options: ComponentConstructorOptions<Properties<Props, Slots>>);
-```
-
-<div class="ts-block-property-details">
-
-<div class="ts-block-property-bullets">
-
-- <span class="tag deprecated">deprecated</span> This constructor only exists when using the `asClassComponent` compatibility helper, which
-is a stop-gap solution. Migrate towards using `mount` instead. See
-https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes for more info.
-
-</div>
-
-</div>
-</div>
-
-<div class="ts-block-property">
-
-```dts
-$destroy(): void;
-```
-
-<div class="ts-block-property-details">
-
-<div class="ts-block-property-bullets">
-
-- <span class="tag deprecated">deprecated</span> This method only exists when using one of the legacy compatibility helpers, which
-is a stop-gap solution. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes
-for more info.
-
-</div>
-
-</div>
-</div>
-
-<div class="ts-block-property">
-
-```dts
-$on<K extends Extract<keyof Events, string>>(
-	type: K,
-	callback: (e: Events[K]) => void
-): () => void;
-```
-
-<div class="ts-block-property-details">
-
-<div class="ts-block-property-bullets">
-
-- <span class="tag deprecated">deprecated</span> This method only exists when using one of the legacy compatibility helpers, which
-is a stop-gap solution. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes
-for more info.
-
-</div>
-
-</div>
-</div>
-
-<div class="ts-block-property">
-
-```dts
-$set(props: Partial<Props>): void;
-```
-
-<div class="ts-block-property-details">
-
-<div class="ts-block-property-bullets">
-
-- <span class="tag deprecated">deprecated</span> This method only exists when using one of the legacy compatibility helpers, which
-is a stop-gap solution. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes
-for more info.
-
-</div>
-
-</div>
-</div></div>
-
-## SvelteComponentTyped
-
-<blockquote class="tag deprecated">
-
-Use `Component` instead. See [migration guide](https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes) for more information.
-
-</blockquote>
-
-<div class="ts-block">
-
-```dts
-class SvelteComponentTyped<
-	Props extends Record<string, any> = Record<string, any>,
-	Events extends Record<string, any> = any,
-	Slots extends Record<string, any> = any
-> extends SvelteComponent<Props, Events, Slots> {}
-```
-
-</div>
 
 

--- a/apps/svelte.dev/content/docs/svelte/98-reference/21-svelte-reactivity.md
+++ b/apps/svelte.dev/content/docs/svelte/98-reference/21-svelte-reactivity.md
@@ -22,6 +22,19 @@ Svelte provides reactive versions of various built-ins like `SvelteMap`, `Svelte
 <input bind:value={url.href} />
 ```
 
+
+
+```js
+// @noErrors
+import {
+	SvelteDate,
+	SvelteMap,
+	SvelteSet,
+	SvelteURL,
+	SvelteURLSearchParams
+} from 'svelte/reactivity';
+```
+
 ## SvelteDate
 
 <div class="ts-block">
@@ -47,6 +60,8 @@ constructor(...params: any[]);
 
 <div class="ts-block-property-details"></div>
 </div></div>
+
+
 
 ## SvelteMap
 
@@ -83,6 +98,8 @@ set(key: K, value: V): this;
 <div class="ts-block-property-details"></div>
 </div></div>
 
+
+
 ## SvelteSet
 
 <div class="ts-block">
@@ -118,6 +135,8 @@ add(value: T): this;
 <div class="ts-block-property-details"></div>
 </div></div>
 
+
+
 ## SvelteURL
 
 <div class="ts-block">
@@ -144,6 +163,8 @@ get searchParams(): SvelteURLSearchParams;
 <div class="ts-block-property-details"></div>
 </div></div>
 
+
+
 ## SvelteURLSearchParams
 
 <div class="ts-block">
@@ -169,5 +190,7 @@ class SvelteURLSearchParams extends URLSearchParams {/*…*/}
 
 <div class="ts-block-property-details"></div>
 </div></div>
+
+
 
 

--- a/apps/svelte.dev/scripts/sync-docs/types.ts
+++ b/apps/svelte.dev/scripts/sync-docs/types.ts
@@ -152,7 +152,9 @@ export async function get_types(code: string, statements: ts.NodeArray<ts.Statem
 					.trim();
 
 				const collection =
-					ts.isVariableStatement(statement) || ts.isFunctionDeclaration(statement)
+					ts.isVariableStatement(statement) ||
+					ts.isClassDeclaration(statement) ||
+					ts.isFunctionDeclaration(statement)
 						? exports
 						: types;
 


### PR DESCRIPTION
we auto-generate these blocks for each module...

<img width="789" alt="image" src="https://github.com/user-attachments/assets/81bc6cdb-0185-4e59-8716-52a45f598b68">

...but we only include function and variable declarations, not classes, meaning that stuff gets excluded from e.g. `svelte/reactivity`