### PR TITLE
fix: Fix misspelling in community section of home page

### DIFF
--- a/apps/svelte.dev/src/routes/_home/Community.svelte
+++ b/apps/svelte.dev/src/routes/_home/Community.svelte
@@ -5,7 +5,7 @@
 <Section --max-width="200rem">
 	<h2>join our friendly community</h2>
 	<p>
-		Our sister organisation, <a href="https://www.sveltesociety.dev/">Svelte Society</a>, organises
+		Our sister organization, <a href="https://www.sveltesociety.dev/">Svelte Society</a>, organizes
 		events around the globe. Find your chapter and join us in
 		<a href="/chat">our Discord server</a>.
 	</p>


### PR DESCRIPTION
###  Changes

- Tiny PR to addressed to misspelled words on homepage in the community section. Was immediately noticably to me so figured I fix.

### Related Issue

- N/A

### PR Type

- Fix