### PR TITLE
feat: Render full posts on RSS feed

### DIFF
--- a/apps/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/apps/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -35,7 +35,7 @@ const get_rss = async (posts) => {
 		<item>
 			<title>${escapeHTML(post.metadata.title)}</title>
 			<link>https://svelte.dev/${post.slug}</link>
-		  <author>${escapeHTML(post.metadata.author)}</author>
+			<author>${escapeHTML(post.metadata.author)}</author>
 			<description>${escapeHTML(await render_content(post.file, post.body))}</description>
 			<pubDate>${formatPubdate(/** @type {string} */ (post.file.split('/').pop()).slice(0, 10))}</pubDate>
 		</item>

--- a/apps/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/apps/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -1,4 +1,5 @@
 import { index } from '$lib/server/content';
+import { render_content } from '$lib/server/renderer';
 
 export const prerender = false; // TODO
 
@@ -25,8 +26,24 @@ function escapeHTML(html) {
 }
 
 /** @param {import('@sveltejs/site-kit').Document[]} posts */
-const get_rss = (posts) =>
+const get_rss = async (posts) => {
+	const renderedPosts = await Promise.all(
+		posts
+			.filter((post) => !post.metadata.draft)
+			.map(
+				async (post) => `
+		<item>
+			<title>${escapeHTML(post.metadata.title)}</title>
+			<link>https://svelte.dev/${post.slug}</link>
+		  <author>${escapeHTML(post.metadata.author)}</author>
+			<description>${escapeHTML(await render_content(post.file, post.body))}</description>
+			<pubDate>${formatPubdate(/** @type {string} */ (post.file.split('/').pop()).slice(0, 10))}</pubDate>
+		</item>
 	`
+			)
+	);
+
+	return `
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 
@@ -39,19 +56,7 @@ const get_rss = (posts) =>
 		<title>Svelte</title>
 		<link>https://svelte.dev/blog</link>
 	</image>
-	${posts
-		.filter((post) => !post.metadata.draft)
-		.map(
-			(post) => `
-		<item>
-			<title>${escapeHTML(post.metadata.title)}</title>
-			<link>https://svelte.dev/${post.slug}</link>
-			<description>${escapeHTML(post.metadata.description)}</description>
-			<pubDate>${formatPubdate(/** @type {string} */ (post.file.split('/').pop()).slice(0, 10))}</pubDate>
-		</item>
-	`
-		)
-		.join('')}
+			${renderedPosts.join('')}
 </channel>
 
 </rss>
@@ -59,9 +64,10 @@ const get_rss = (posts) =>
 		.replace(/>[^\S]+/gm, '>')
 		.replace(/[^\S]+</gm, '<')
 		.trim();
+};
 
 export async function GET() {
-	return new Response(get_rss(index.blog.children), {
+	return new Response(await get_rss(index.blog.children), {
 		headers: {
 			'Cache-Control': `max-age=${30 * 60 * 1e3}`,
 			'Content-Type': 'application/rss+xml'


### PR DESCRIPTION
Renders the full post in the RSS feed for the svelte blog. With this change the feed will be friendlier for those with unstable connections (e.g. subway) since you can download posts whenever you have a connection rather than having to navigate to an external URL each time. It's a nicer experience since you don't have to move away from your reader.

Closes https://github.com/sveltejs/svelte.dev/issues/837.

Tested on NetNewswire from localhost feed and it works well.

## before

<img width="1424" alt="imagen" src="https://github.com/user-attachments/assets/7b75278d-5b5b-4582-a275-a5ed09d0e286">


## after

<img width="1423" alt="imagen" src="https://github.com/user-attachments/assets/6d4f92da-0401-45ae-b7bc-b7c481793e5e">


### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
