### PR TITLE
fix: Remove duplicate info about {#each} block

### DIFF
--- a/apps/svelte.dev/content/docs/svelte/03-template-syntax/03-each.md
+++ b/apps/svelte.dev/content/docs/svelte/03-template-syntax/03-each.md
@@ -23,8 +23,6 @@ Iterating over values can be done with an each block. The values in question can
 </ul>
 ```
 
-You can use each blocks to iterate over any array or array-like value — that is, any object with a `length` property.
-
 An each block can also specify an _index_, equivalent to the second argument in an `array.map(...)` callback:
 
 ```svelte


### PR DESCRIPTION
The documentation has the definition of types supported by #each in svelte 3 right after the version of svelte 4, which started supporting iterables

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
