### PR TITLE
fix: make Safari rendering of summary elements the same as other browsers

### DIFF
--- a/apps/svelte.dev/src/lib/components/ModalDropdown.svelte
+++ b/apps/svelte.dev/src/lib/components/ModalDropdown.svelte
@@ -102,6 +102,10 @@
 		align-items: center;
 		justify-content: center;
 		user-select: none;
+
+		&::-webkit-details-marker {
+			display: none;
+		}
 	}
 
 	details[open] summary::before {

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -523,6 +523,10 @@
 				font: var(--sk-font-body-small);
 				user-select: none;
 
+				&::-webkit-details-marker {
+					display: none;
+				}
+
 				.legacy &::after {
 					position: absolute;
 					display: flex;

--- a/packages/site-kit/src/lib/search/SearchResultList.svelte
+++ b/packages/site-kit/src/lib/search/SearchResultList.svelte
@@ -111,6 +111,10 @@
 			span:not(:last-child)::after {
 				content: ' • ';
 			}
+
+			&::-webkit-details-marker {
+				display: none;
+			}
 		}
 	}
 

--- a/packages/site-kit/src/lib/styles/utils/nav.css
+++ b/packages/site-kit/src/lib/styles/utils/nav.css
@@ -13,6 +13,10 @@
 			display: block;
 			user-select: none;
 
+			&::-webkit-details-marker {
+				display: none;
+			}
+
 			&::before {
 				content: '';
 				position: absolute;


### PR DESCRIPTION
For Chromium-based browsers and Firefox, setting `display: block` or `display: flex` on a `<summary>` element will hide the expand/contract arrow icon. Svelte does this and provides alternative affordances to indicate whether the summary is open.

Safari needs a bit more help, requiring `display:none` on the `::-webkit-details-marker` pseudoelement.

This PR adds `::-webkit-details-marker` to the 4 places I could find summary elements, making Safari consistent with other browsers.

### Tutorial navigation menu trigger button

Before:

<img width="217" alt="image" src="https://github.com/user-attachments/assets/f6ce785d-5dbd-40ec-ad76-16d53aee4cc1">

After:

<img width="224" alt="image" src="https://github.com/user-attachments/assets/07e669b1-7208-4402-93da-4f3f6c815919">

### Tutorial navigation menu

Before:

<img width="227" alt="image" src="https://github.com/user-attachments/assets/bf0a2d15-a661-4b88-9637-e413da9c2c58">

After:

<img width="223" alt="image" src="https://github.com/user-attachments/assets/1d854500-36aa-4ea9-a7c7-1168d3678be9">

### In site search

Before:

<img width="302" alt="image" src="https://github.com/user-attachments/assets/7b0d6dc0-5398-4e0b-93e3-61e0683a109e">

After:

<img width="284" alt="image" src="https://github.com/user-attachments/assets/3b83bf08-876b-414d-a035-3efecf4e2bdc">

### In Text.svelte

e.g. on https://svelte.dev/blog/view-transitions

Before:

<img width="814" alt="image" src="https://github.com/user-attachments/assets/59985fd2-29f7-46f7-81e0-8e3e0c1a9450">

After:

<img width="799" alt="image" src="https://github.com/user-attachments/assets/d0b478d7-c45b-4e04-a16b-59f288c5ebed">
