### PR TITLE
fix: correct GH issues link on 404 page

### DIFF
--- a/apps/svelte.dev/src/routes/+error.svelte
+++ b/apps/svelte.dev/src/routes/+error.svelte
@@ -21,7 +21,7 @@
 					If you were expecting to find something here, please drop by the
 					<a href="/chat"> Discord chatroom </a>
 					and let us know, or raise an issue on
-					<a href="https://github.com/sveltejs/sites">GitHub</a>. Thanks!
+					<a href="https://github.com/sveltejs/svelte.dev/issues">GitHub</a>. Thanks!
 				</p>
 			{:else}
 				<h1>Yikes!</h1>


### PR DESCRIPTION
The 500 error page had the link pointing to the correct repo, but the 404 error page still had the old `sites` repo.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
