### PR TITLE
fix: include .env files in tutorial assets

### DIFF
--- a/apps/svelte.dev/src/lib/server/content.ts
+++ b/apps/svelte.dev/src/lib/server/content.ts
@@ -8,7 +8,7 @@ const documents = import.meta.glob<string>('../../../content/**/*.md', {
 	import: 'default'
 });
 
-const assets = import.meta.glob<string>('../../../content/**/+assets/**', {
+const assets = import.meta.glob<string>(['../../../content/**/+assets/**', '../../../content/**/+assets/**/.env'], {
 	eager: true,
 	query: '?url',
 	import: 'default'

--- a/apps/svelte.dev/src/lib/server/content.ts
+++ b/apps/svelte.dev/src/lib/server/content.ts
@@ -8,11 +8,14 @@ const documents = import.meta.glob<string>('../../../content/**/*.md', {
 	import: 'default'
 });
 
-const assets = import.meta.glob<string>(['../../../content/**/+assets/**', '../../../content/**/+assets/**/.env'], {
-	eager: true,
-	query: '?url',
-	import: 'default'
-});
+const assets = import.meta.glob<string>(
+	['../../../content/**/+assets/**', '../../../content/**/+assets/**/.env'],
+	{
+		eager: true,
+		query: '?url',
+		import: 'default'
+	}
+);
 
 // https://github.com/vitejs/vite/issues/17453
 export const index = await create_index(documents, assets, '../../../content', read);


### PR DESCRIPTION
Should address the broken tutorials around `.env` handling: https://github.com/sveltejs/svelte.dev/issues/690

I added just the `.env` files to the glob import, not sure if it makes to include all dot-prefixed files, and from what I understand, Vite's glob import doesn't support the `dot: true` option in `tinyglobby`