### PR TITLE
support importing different versions of packages

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -291,7 +291,7 @@ async function get_bundle(
 				const pkg_url =
 					pkg_name === 'svelte'
 						? `${svelte_url}/package.json`
-						: `${packages_url}/${pkg_name}/package.json`;
+						: `${packages_url}/${pkg_name}@${match[2] ?? 'latest'}/package.json`;
 				const subpath = `.${match[3] ?? ''}`;
 
 				// if this was imported by one of our files, add it to the `imports` set


### PR DESCRIPTION
This allows us to do things like this in the playground:

```js
import foo from 'foo@next';
```

My main motivation is so that I can import `@threlte/core@next`, though it doesn't currently work for unrelated reasons