### PR TITLE
Fix Responsive Issue in svelte.dev Homepage

### DIFF
--- a/apps/svelte.dev/src/routes/_home/Testimonials.svelte
+++ b/apps/svelte.dev/src/routes/_home/Testimonials.svelte
@@ -4,8 +4,6 @@
 			class="pronunciation"
 			alt="Svelte pronunciation guide"
 			src="./svelte-pronunciation.svg"
-			width="178"
-			height="54"
 		/>
 
 		<span class="description">
@@ -73,6 +71,7 @@
 		position: relative;
 		aspect-ratio: 457.4 / 138.8;
 		height: var(--sk-font-size-h1);
+		width: auto;
 		bottom: -0.3em;
 	}
 

--- a/apps/svelte.dev/src/routes/_home/Testimonials.svelte
+++ b/apps/svelte.dev/src/routes/_home/Testimonials.svelte
@@ -4,6 +4,8 @@
 			class="pronunciation"
 			alt="Svelte pronunciation guide"
 			src="./svelte-pronunciation.svg"
+			width="178"
+			height="54"
 		/>
 
 		<span class="description">


### PR DESCRIPTION
Hi! This PR is a fix of responsive issue in svelte.dev homepage: https://github.com/sveltejs/svelte.dev/issues/982. I see the update version of `@sveltejs/enhanced-img` in commit https://github.com/sveltejs/svelte.dev/commit/d6a64f82bef4e1fc6226390698d63722613e746c makes the svelte.dev homepage not responsive. If I see more detail, the `svelte-pronounciation.svg` needs to set width and height expicitly as the quick solution. 

I have see the PR of `@sveltejs/enhanced-img` https://github.com/sveltejs/kit/pull/13126/files#diff-f318d5cf67f7e975aecc26dfb6056ae55058442cf36dd7e6f53c4a292edeb2d9. But, it looks like Ben forgot to test the `svelte-pronounciation.svg` asset.

Here's the GIF video demonstration (please wait for seconds to make it appears).

![Screen Recording 2024-12-12 at 08 41 33](https://github.com/user-attachments/assets/70e36435-5438-4373-9799-dbdfe3065e0b)

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time.
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
