### PR TITLE
fix: restore surrounding newlines with `lang="ts"`

### DIFF
--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -369,7 +369,7 @@ async function generate_ts_from_js(
 
 		if (!ts) return;
 
-		return code.replace(outer, `<script lang="ts">${ts}</script>`);
+		return code.replace(outer, `<script lang="ts">\n${ts}\n</script>`);
 	}
 
 	return await convert_to_ts(code);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4119a6c3-78d0-4d18-aae8-8ea87108d09f)