### PR TITLE
fix: replace incorrect jsdoc typeExpression in AST traversal

### DIFF
--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -420,13 +420,13 @@ async function convert_to_ts(js_code: string, indent = '', offset = '') {
 
 			for (const tag of tags) {
 				if (ts.isJSDocTypeTag(tag)) {
-					type = get_type_info(tag.typeExpression);
+					type = get_type_info(get_jsdoc_type_expression_text(tag.getText()));
 				} else if (ts.isJSDocParameterTag(tag)) {
-					params.push(get_type_info(tag.typeExpression!));
+					params.push(get_type_info(tag.typeExpression?.getText()!));
 				} else if (ts.isJSDocReturnTag(tag)) {
-					returns = get_type_info(tag.typeExpression!);
+					returns = get_type_info(tag.typeExpression?.getText()!);
 				} else if (ts.isJSDocSatisfiesTag(tag)) {
-					satisfies = get_type_info(tag.typeExpression!);
+					satisfies = get_type_info(tag.typeExpression?.getText()!);
 				} else {
 					throw new Error('Unhandled tag');
 				}
@@ -546,10 +546,9 @@ async function convert_to_ts(js_code: string, indent = '', offset = '') {
 
 	return transformed === js_code ? undefined : transformed;
 
-	function get_type_info(expression: ts.JSDocTypeExpression) {
-		const type = expression
-			?.getText()!
-			.slice(1, -1) // remove surrounding `{` and `}`
+	function get_type_info(expressionText: string) {
+		const type = expressionText
+			.replace(/^\{|\}$/g, '') // remove surrounding `{` and `}`
 			.replace(/ \* ?/gm, '')
 			.replace(/import\('(.+?)'\)\.(\w+)(?:(<.+>))?/gms, (_, source, name, args = '') => {
 				const existing = imports.get(source);
@@ -563,6 +562,10 @@ async function convert_to_ts(js_code: string, indent = '', offset = '') {
 			});
 
 		return type;
+	}
+
+	function get_jsdoc_type_expression_text(jsdocText: string): string {
+		return jsdocText.replace(/^@type\s*/, '').trim();
 	}
 }
 

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -546,8 +546,8 @@ async function convert_to_ts(js_code: string, indent = '', offset = '') {
 
 	return transformed === js_code ? undefined : transformed;
 
-	function get_type_info(expressionText: string) {
-		const type = expressionText
+	function get_type_info(text: string) {
+		const type = text
 			.replace(/^\{|\}$/g, '') // remove surrounding `{` and `}`
 			.replace(/ \* ?/gm, '')
 			.replace(/import\('(.+?)'\)\.(\w+)(?:(<.+>))?/gms, (_, source, name, args = '') => {
@@ -564,8 +564,8 @@ async function convert_to_ts(js_code: string, indent = '', offset = '') {
 		return type;
 	}
 
-	function get_jsdoc_type_expression_text(jsdocText: string): string {
-		return jsdocText.replace(/^@type\s*/, '').trim();
+	function get_jsdoc_type_expression_text(text: string): string {
+		return text.replace(/^@type\s*/, '').trim();
 	}
 }
 


### PR DESCRIPTION
fixes #647 

the typeExpression of a JSDocTypeTag is truncated due to comment syntax.

| AS-IS | TO-BE |
|--------|--------|
| <img width="980" alt="image" src="https://github.com/user-attachments/assets/3bdd1fd2-7835-47e7-8cdf-47e5e085e52e" /> | <img width="789" alt="image" src="https://github.com/user-attachments/assets/d176e8b2-5fd0-4ba8-90fa-7eac45bc7fdb" /> |  



This PR addresses an issue where the typeExpression of a JSDocTypeTag was being truncated due to comment syntax (e.g., // ...) when converting JavaScript code with JSDoc to TypeScript.

It appears there is a bug in TypeScript’s parsing of the JSDoc `@type` tag, where it assigns the typeExpression property incorrectly ([parseJSDocTypeExpression](https://github.com/microsoft/TypeScript/blob/f69580f82146bebfb2bee8c7b8666af0e04c7e34/src/compiler/parser.ts#L8770), [reproduction](https://codesandbox.io/p/sandbox/6qxss2)).

In Svelte documentation, I determined that this issue can be handled without affecting other documents by using an alternative approach.

### Changes

In the previous implementation, the typeExpression field in the AST node was used, but it could be incorrect when the JSDoc type tag had multiline types or contained comment expressions.

To resolve this:
	•	I modified the AST traversal logic to avoid using the typeExpression field directly.
	•	A helper function was added to correctly handle the type expression and ensure proper type information is generated.



### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time.
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
