### PR TITLE
make prerender configurable

### DIFF
--- a/apps/svelte.dev/.env
+++ b/apps/svelte.dev/.env
@@ -3,3 +3,6 @@ SUPABASE_KEY=
 
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+
+# disable prerendering with `PRERENDER=false pnpm build` — this is useful for speeding up builds when previewing locally
+PRERENDER=true

--- a/apps/svelte.dev/README.md
+++ b/apps/svelte.dev/README.md
@@ -35,3 +35,11 @@ When writing content for the tutorial, you need to be aware of the differences o
 ### Dependencies
 
 If you look in the site's package.json you'll notice several dependencies that don't appear to be used, such as `@testing-library/svelte`. These are present because they're referenced in the docs, and Twoslash needs to be able to find type definitions in order to typecheck snippets. Installing the dependencies was deemed preferable to faking it with `declare module`, since we're liable to end up with fictional types that way.
+
+### Prerendering
+
+Most of the site is prerendered. Since that involves some fairly expensive work, it can take a while. To build the site _without_ prerendering — for example, because you need to debug an issue that's affecting production builds — set the `PRERENDER` environment variable to `false`:
+
+```bash
+PRERENDER=false pnpm build
+```

--- a/apps/svelte.dev/src/routes/(authed)/+layout.server.js
+++ b/apps/svelte.dev/src/routes/(authed)/+layout.server.js
@@ -1,5 +1,7 @@
 import * as session from '$lib/db/session';
 
+export const prerender = false;
+
 /** @type {import('@sveltejs/adapter-vercel').Config} */
 export const config = {
 	runtime: 'nodejs20.x' // see https://github.com/sveltejs/svelte/pull/9136

--- a/apps/svelte.dev/src/routes/+layout.server.ts
+++ b/apps/svelte.dev/src/routes/+layout.server.ts
@@ -1,5 +1,9 @@
+import { PRERENDER } from '$env/static/private';
 import { docs, index } from '$lib/server/content';
 import type { BannerData, NavigationLink } from '@sveltejs/site-kit';
+
+// by default, all pages are prerendered
+export const prerender = PRERENDER !== 'false';
 
 const nav_links: NavigationLink[] = [
 	{

--- a/apps/svelte.dev/src/routes/+page.server.js
+++ b/apps/svelte.dev/src/routes/+page.server.js
@@ -1,1 +1,0 @@
-export const prerender = true;

--- a/apps/svelte.dev/src/routes/blog/+page.server.js
+++ b/apps/svelte.dev/src/routes/blog/+page.server.js
@@ -1,7 +1,5 @@
 import { blog_posts } from '$lib/server/content';
 
-export const prerender = true;
-
 export async function load() {
 	const posts = blog_posts
 		.map((document) => ({

--- a/apps/svelte.dev/src/routes/blog/[slug]/+page.server.js
+++ b/apps/svelte.dev/src/routes/blog/[slug]/+page.server.js
@@ -2,8 +2,6 @@ import { error } from '@sveltejs/kit';
 import { blog_posts } from '$lib/server/content';
 import { render_content } from '$lib/server/renderer';
 
-export const prerender = true;
-
 export async function load({ params }) {
 	const document = blog_posts.find((document) => document.slug === `blog/${params.slug}`);
 

--- a/apps/svelte.dev/src/routes/chat/+server.js
+++ b/apps/svelte.dev/src/routes/chat/+server.js
@@ -1,3 +1,5 @@
+export const prerender = true;
+
 export function GET() {
 	return new Response(undefined, {
 		status: 302,

--- a/apps/svelte.dev/src/routes/docs/+page.server.js
+++ b/apps/svelte.dev/src/routes/docs/+page.server.js
@@ -1,1 +1,0 @@
-export const prerender = true;

--- a/apps/svelte.dev/src/routes/docs/[...path]/+layout.server.ts
+++ b/apps/svelte.dev/src/routes/docs/[...path]/+layout.server.ts
@@ -2,8 +2,6 @@ import { docs } from '$lib/server/content';
 import { redirect } from '@sveltejs/kit';
 import { error } from '@sveltejs/kit';
 
-export const prerender = true;
-
 export async function load({ params }) {
 	const topic = params.path.split('/')[0];
 	const document = docs.topics[`docs/${topic}`];

--- a/apps/svelte.dev/src/routes/docs/kit/modules/+page.svelte
+++ b/apps/svelte.dev/src/routes/docs/kit/modules/+page.svelte
@@ -62,9 +62,9 @@
 		['$app-paths-assets', ['`$app/paths#assets`', '/docs/kit/$app-paths#assets']],
 		['$app-paths-base', ['`$app/paths#base`', '/docs/kit/$app-paths#base']],
 		['$app-paths-resolveroute', ['`$app-paths#resolveRoute`', '/docs/kit/$app-paths#resolveRoute']],
-		['$app-server-read', ['`$app/paths#read`', '/docs/kit/$app-paths#read']],
+		['$app-server-read', ['`$app/server#read`', '/docs/kit/$app-server#read']],
 		['$app-stores-getstores', ['`$app/stores#getStores`', '/docs/kit/$app-stores#getStores']],
-		['$app-stores-navigating', ['`$app/stores#assets`', '/docs/kit/$app-stores#assets']],
+		['$app-stores-navigating', ['`$app/stores#navigating`', '/docs/kit/$app-stores#navigating']],
 		['$app-stores-page', ['`$app/stores#page`', '/docs/kit/$app-stores#page']],
 		['$app-stores-updated', ['`$app/stores#updated`', '/docs/kit/$app-stores#updated']],
 		['$lib-$lib-server', ['`$lib`', '/docs/kit/$lib']],
@@ -76,14 +76,20 @@
 			['`$service-worker#prerendered`', '/docs/kit/$service-worker#prerendered']
 		],
 		['$service-worker-version', ['`$service-worker#version`', '/docs/kit/$service-worker#version']],
-		['sveltejs-kit-version', ['`@sveltejs/kit#VERSION`', '/@sveltejs-kit#VERSION']],
-		['sveltejs-kit-error', ['`@sveltejs/kit#error`', '/@sveltejs-kit#error']],
-		['sveltejs-kit-fail', ['`@sveltejs/kit#fail`', '/@sveltejs-kit#fail']],
-		['sveltejs-kit-ishttperror', ['`@sveltejs/kit#isHttpError`', '/@sveltejs-kit#isHttpError']],
-		['sveltejs-kit-isredirect', ['`@sveltejs/kit#isRedirect`', '/@sveltejs-kit#isRedirect']],
-		['sveltejs-kit-json', ['`@sveltejs/kit#json`', '/@sveltejs-kit#json']],
-		['sveltejs-kit-redirect', ['`@sveltejs/kit#redirect`', '/@sveltejs-kit#redirect']],
-		['sveltejs-kit-text', ['`@sveltejs/kit#text`', '/@sveltejs-kit#text']],
+		['sveltejs-kit-version', ['`@sveltejs/kit#VERSION`', '/docs/kit/@sveltejs-kit#VERSION']],
+		['sveltejs-kit-error', ['`@sveltejs/kit#error`', '/docs/kit/@sveltejs-kit#error']],
+		['sveltejs-kit-fail', ['`@sveltejs/kit#fail`', '/docs/kit/@sveltejs-kit#fail']],
+		[
+			'sveltejs-kit-ishttperror',
+			['`@sveltejs/kit#isHttpError`', '/docs/kit/@sveltejs-kit#isHttpError']
+		],
+		[
+			'sveltejs-kit-isredirect',
+			['`@sveltejs/kit#isRedirect`', '/docs/kit/@sveltejs-kit#isRedirect']
+		],
+		['sveltejs-kit-json', ['`@sveltejs/kit#json`', '/docs/kit/@sveltejs-kit#json']],
+		['sveltejs-kit-redirect', ['`@sveltejs/kit#redirect`', '/docs/kit/@sveltejs-kit#redirect']],
+		['sveltejs-kit-text', ['`@sveltejs/kit#text`', '/docs/kit/@sveltejs-kit#text']],
 		[
 			'sveltejs-kit-hooks-sequence',
 			['`@sveltejs/kit/hooks#sequence`', '/docs/kit/@sveltejs-kit-hooks#sequence']

--- a/apps/svelte.dev/src/routes/e/[code]/+page.server.ts
+++ b/apps/svelte.dev/src/routes/e/[code]/+page.server.ts
@@ -17,6 +17,7 @@ import { error, redirect } from '@sveltejs/kit';
 // 		[...page.body.matchAll(/(^|\n)### (\w+)/g)].map(([, , code]) => ({ code }))
 // 	);
 // }
+export const prerender = false;
 
 export async function load({ params, fetch }) {
 	const codes: Record<string, Record<string, string[]>> = await fetch('/e/tmp/codes.json').then(

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/+page.server.ts
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/+page.server.ts
@@ -1,8 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import { load_exercise } from './content.server';
 
-export const prerender = true;
-
 export async function load({ params }) {
 	if (!params.slug || params.slug === 'svelte') redirect(307, '/tutorial/svelte/welcome-to-svelte');
 	if (params.slug === 'kit') redirect(307, '/tutorial/kit/introducing-sveltekit');


### PR DESCRIPTION
This PR tweaks prerender config. By default, everything is prerendered except `/e/[slug]`, `/apps`, and `/playground/[slug]`, but if `PRERENDER=false` then it will be disabled for everything except a few server routes.

This means you can do `PRERENDER=false pnpm build` and everything builds _waaaaay_ faster, which is useful for debugging production issues locally.