### PR TITLE
fix: Add missing {@render children()} in tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/index.md
+++ b/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/index.md
@@ -31,6 +31,8 @@ We can also add some UI to these two routes by adding a `src/routes/(authed)/+la
 	let { children } = $props();
 </script>
 
+{@render children()}
+
 <form method="POST" action="/logout">
 	<button>log out</button>
 </form>


### PR DESCRIPTION
Fixes code block so that it is aligned with the [solved file](https://github.com/sveltejs/svelte.dev/blob/main/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/%2Bassets/app-b/src/routes/(authed)/%2Blayout.svelte#L5).
