### PR TITLE
docs: render children in layout

### DIFF
--- a/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/index.md
+++ b/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/index.md
@@ -31,6 +31,8 @@ We can also add some UI to these two routes by adding a `src/routes/(authed)/+la
 	let { children } = $props();
 </script>
 
+{@render children()}
+
 <form method="POST" action="/logout">
 	<button>log out</button>
 </form>


### PR DESCRIPTION
Children were not rendered as they were missing from the layout file.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
