### PR TITLE
remove svelte-persisted-store

### DIFF
--- a/packages/site-kit/package.json
+++ b/packages/site-kit/package.json
@@ -42,8 +42,7 @@
 		"@shikijs/twoslash": "^1.22.0",
 		"esm-env": "^1.0.0",
 		"json5": "^2.2.3",
-		"shiki": "^1.22.0",
-		"svelte-persisted-store": "^0.9.2"
+		"shiki": "^1.22.0"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "^2.12.1",

--- a/packages/site-kit/src/lib/actions/legacy-details.ts
+++ b/packages/site-kit/src/lib/actions/legacy-details.ts
@@ -1,9 +1,8 @@
 import { page } from '$app/stores';
-import { persisted } from 'svelte-persisted-store';
-import { get } from 'svelte/store';
 import { fix_position } from './utils';
+import { Persisted } from '../state';
 
-const show_legacy = persisted('svelte:show-legacy', true);
+const show_legacy = new Persisted<'open' | 'closed'>('sv:show-legacy', 'open');
 
 export function legacy_details(node: HTMLElement) {
 	function update() {
@@ -16,7 +15,7 @@ export function legacy_details(node: HTMLElement) {
 		}
 
 		const details = node.querySelectorAll('details.legacy') as NodeListOf<HTMLDetailsElement>;
-		const show = get(show_legacy);
+		const show = show_legacy.current === 'open';
 
 		/** Whether the toggle was initiated by user action or `element.open = !element.open` */
 		let secondary = false;
@@ -29,7 +28,7 @@ export function legacy_details(node: HTMLElement) {
 				if (secondary) return;
 				secondary = true;
 
-				show_legacy.set(detail.open);
+				show_legacy.current = detail.open ? 'open' : 'closed';
 
 				fix_position(detail, () => {
 					for (const other of details) {

--- a/packages/site-kit/src/lib/components/Banner.svelte
+++ b/packages/site-kit/src/lib/components/Banner.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
 	import { quintOut } from 'svelte/easing';
 	import { fade } from 'svelte/transition';
-	import { persisted } from 'svelte-persisted-store';
 	import Icon from './Icon.svelte';
 	import type { BannerData } from '../types';
 	import { browser } from '$app/environment';
+	import { Persisted } from '../state';
 
 	let { banner }: { banner: BannerData } = $props();
 
-	const hidden = persisted<Record<string, boolean>>('svelte:hidden-banners', {});
+	const persisted = new Persisted<string>('sv:hidden-banners', '{}');
+	const hidden = $derived(JSON.parse(persisted.current));
 	const time = +new Date();
 
 	let visible = $derived(
-		browser && !$hidden[banner.id] && time > +banner.start && time < +banner.end
+		browser && !hidden[banner.id] && time > +banner.start && time < +banner.end
 	);
 
 	$effect(() => {
@@ -40,7 +41,10 @@
 			aria-label="Dismiss"
 			class="raised primary"
 			onclick={() => {
-				$hidden[banner.id] = true;
+				persisted.current = JSON.stringify({
+					...hidden,
+					[banner.id]: true
+				});
 			}}
 		>
 			<Icon name="close" />

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation';
 	import type { Snippet } from 'svelte';
-	import { prefers_ts } from '../stores/prefers_ts';
+	import { code_preference } from '../state/code_preference';
 	import { fix_position } from '../actions/utils';
 
 	let { children }: { children: Snippet } = $props();
@@ -14,14 +14,14 @@
 		const inputs = container.querySelectorAll('.ts-toggle') as NodeListOf<HTMLInputElement>;
 
 		for (const input of inputs) {
-			input.checked = $prefers_ts;
+			input.checked = code_preference.current === 'typescript';
 		}
 	}
 
 	function toggle(e: Event) {
 		if ((e.target as HTMLElement).classList.contains('ts-toggle')) {
 			const input = e.target as HTMLInputElement;
-			$prefers_ts = input.checked;
+			code_preference.current = input.checked ? 'typescript' : 'javascript';
 			fix_position(input, update);
 		}
 	}

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -3,7 +3,8 @@ Top navigation bar for the application. It provides a slot for the left side, th
 -->
 
 <script lang="ts">
-	import { overlay_open, searching, on_this_page_open } from '../stores';
+	import { overlay_open, on_this_page_open } from '../stores';
+	import { search } from '../state/search.svelte';
 	import Icon from '../components/Icon.svelte';
 	import { page } from '$app/stores';
 	import ThemeToggle from '../components/ThemeToggle.svelte';
@@ -67,7 +68,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 
 <nav
 	class:visible
-	style:z-index={$overlay_open && ($searching || $on_this_page_open) ? 80 : null}
+	style:z-index={$overlay_open && (search.active || $on_this_page_open) ? 80 : null}
 	aria-label="Primary"
 >
 	<a class="home-link" href="/" title={home_title} aria-label="Svelte"></a>
@@ -145,7 +146,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			aria-label="Search"
 			class="raised icon search"
 			onclick={() => {
-				$searching = true;
+				search.active = true;
 			}}
 		>
 			<Icon name="search" size={18} />

--- a/packages/site-kit/src/lib/search/Search.svelte
+++ b/packages/site-kit/src/lib/search/Search.svelte
@@ -3,7 +3,7 @@ Renders a search widget which when clicked (or the corresponding keyboard shortc
 -->
 <script lang="ts">
 	import { BROWSER } from 'esm-env';
-	import { search_query, searching } from '../stores/search';
+	import { search } from '../state/search.svelte';
 
 	let { q = '', label = 'Search' }: { q?: string; label?: string } = $props();
 </script>
@@ -12,20 +12,20 @@ Renders a search widget which when clicked (or the corresponding keyboard shortc
 	<input
 		value={q}
 		oninput={(e) => {
-			$search_query = e.currentTarget.value;
-			$searching = true;
+			search.query = e.currentTarget.value;
+			search.active = true;
 			e.currentTarget.value = '';
 			e.currentTarget.blur();
 		}}
 		onmousedown={(event) => {
 			event.preventDefault();
 			event.currentTarget.blur();
-			$searching = true;
+			search.active = true;
 		}}
 		ontouchend={(event) => {
 			event.preventDefault();
 			event.currentTarget.blur();
-			$searching = true;
+			search.active = true;
 		}}
 		type="search"
 		name="q"

--- a/packages/site-kit/src/lib/state/code_preference.ts
+++ b/packages/site-kit/src/lib/state/code_preference.ts
@@ -1,0 +1,6 @@
+import { Persisted } from './Persisted.svelte';
+
+export const code_preference = new Persisted<'typescript' | 'javascript'>(
+	'sv:code_preference',
+	'typescript'
+);

--- a/packages/site-kit/src/lib/state/search.svelte.ts
+++ b/packages/site-kit/src/lib/state/search.svelte.ts
@@ -1,0 +1,17 @@
+import { Persisted } from './Persisted.svelte';
+
+class SearchState {
+	#recent = new Persisted<string>('sv:recent-searches', '[]');
+	active = $state(false);
+	query = $state('');
+
+	get recent() {
+		return JSON.parse(this.#recent.current) as string[];
+	}
+
+	set recent(value) {
+		this.#recent.current = JSON.stringify(value);
+	}
+}
+
+export const search = new SearchState();

--- a/packages/site-kit/src/lib/stores/index.ts
+++ b/packages/site-kit/src/lib/stores/index.ts
@@ -1,4 +1,3 @@
 export { mql } from './mql';
 export { nav_open, on_this_page_open, overlay_open, should_nav_autohide } from './nav';
 export { reduced_motion } from './reduced-motion';
-export { search_query, search_recent, searching } from './search';

--- a/packages/site-kit/src/lib/stores/prefers_ts.ts
+++ b/packages/site-kit/src/lib/stores/prefers_ts.ts
@@ -1,3 +1,0 @@
-import { persisted } from 'svelte-persisted-store';
-
-export const prefers_ts = persisted('svelte:prefers-ts', true);

--- a/packages/site-kit/src/lib/stores/search.ts
+++ b/packages/site-kit/src/lib/stores/search.ts
@@ -1,6 +1,0 @@
-import { persisted } from 'svelte-persisted-store';
-import { writable } from 'svelte/store';
-
-export const searching = writable(false);
-export const search_query = writable('');
-export const search_recent = persisted<any[]>('svelte:recent-searches', []);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,9 +485,6 @@ importers:
       shiki:
         specifier: ^1.22.0
         version: 1.22.0
-      svelte-persisted-store:
-        specifier: ^0.9.2
-        version: 0.9.4(svelte@5.14.0)
     devDependencies:
       '@sveltejs/kit':
         specifier: ^2.12.1
@@ -3019,12 +3016,6 @@ packages:
     resolution: {integrity: sha512-T6mqZrySltPCDwfKXWQ6zehipVLk4GWfH1zCMGgRtLlOIFPuw58ZxVYxVvotMJgJaurKi1i14viB2GIRKXeJTQ==}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.1
-
-  svelte-persisted-store@0.9.4:
-    resolution: {integrity: sha512-Em3cDSsd3fAkQhvNc4+V7ZT86GnIkFrlcKK/oNSHFhF5fbNoavdxvtTZ0pCF2ueG/Oqg5kSbAFxn0rkeICpHUA==}
-    engines: {node: '>=0.14'}
-    peerDependencies:
-      svelte: ^3.48.0 || ^4.0.0 || ^5.0.0-next.0
 
   svelte-preprocess@6.0.3:
     resolution: {integrity: sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==}
@@ -5913,10 +5904,6 @@ snapshots:
       - picomatch
 
   svelte-parse-markup@0.1.5(svelte@5.14.0):
-    dependencies:
-      svelte: 5.14.0
-
-  svelte-persisted-store@0.9.4(svelte@5.14.0):
     dependencies:
       svelte: 5.14.0
 


### PR DESCRIPTION
quick follow-up to #1087 — removes a dependency (and various store uses) in favour of the `Persisted` class