### PR TITLE
fix: repl redirect to playground

### DIFF
--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -57,8 +57,8 @@ export async function handle({ event, resolve }) {
 
 	// For REPL. For some reason, the repl/+page.server.ts file is not working, so
 	// we are doing the redirect here
-	if (event.url.pathname.startsWith('/repl/')) {
-		redirect(307, event.url.pathname.replace('/repl/', '/playground/'));
+	if (event.url.pathname.startsWith('/repl')) {
+		redirect(307, event.url.pathname.replace('/repl', '/playground'));
 	}
 
 	// Best effort to redirect from Svelte 3 tutorial to new tutorial

--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -55,6 +55,12 @@ export async function handle({ event, resolve }) {
 		redirect(307, destination);
 	}
 
+	// For REPL. For some reason, the repl/+page.server.ts file is not working, so
+	// we are doing the redirect here
+	if (event.url.pathname.startsWith('/repl/')) {
+		redirect(307, event.url.pathname.replace('/repl/', '/playground/'));
+	}
+
 	// Best effort to redirect from Svelte 3 tutorial to new tutorial
 	if (event.url.pathname.startsWith('/tutorial/') && event.url.pathname.split('/').length === 2) {
 		redirect(307, event.url.pathname.replace('/tutorial/', '/tutorial/svelte/'));

--- a/apps/svelte.dev/src/routes/repl/[...path]/+page.server.ts
+++ b/apps/svelte.dev/src/routes/repl/[...path]/+page.server.ts
@@ -1,5 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-export function load({ url }) {
-	throw redirect(307, url.href.replace('/repl', '/playground'));
-}


### PR DESCRIPTION
### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
