### PR TITLE
docs: remove useless private fields

### DIFF
--- a/apps/svelte.dev/scripts/sync-docs/types.ts
+++ b/apps/svelte.dev/scripts/sync-docs/types.ts
@@ -122,6 +122,16 @@ export async function get_types(code: string, statements: ts.NodeArray<ts.Statem
 				if (ts.isInterfaceDeclaration(statement) || ts.isClassDeclaration(statement)) {
 					if (statement.members.length > 0) {
 						for (const member of statement.members) {
+							// for some reason, the existence of any private fields results
+							// in a useless `#private;` being added to the definition
+							if (
+								member.name?.getText() === '#private' &&
+								ts.isPropertyDeclaration(member) &&
+								!member.initializer
+							) {
+								continue;
+							}
+
 							children.push(munge_type_element(member as any)!);
 						}
 


### PR DESCRIPTION
For reasons I don't understand, classes with private fields get an uninitialized `#private` property added to the emitted declaration file, causing this:

<img width="789" alt="image" src="https://github.com/user-attachments/assets/1f6c896e-1894-4d23-8fa7-461d5c4dc9e7" />

It's bizarre and useless, so we just remove it

(aside: `SvelteMap` and its siblings need some inline docs. ideally we'd be able to hide unnecessary properties and methods with `@internal` but that doesn't seem to work)