### PR TITLE
fix: using `u` as in the description

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/+assets/app-a/src/lib/App.svelte
@@ -6,7 +6,7 @@
 	function spin(node, { duration }) {
 		return {
 			duration,
-			css: (t) => ``
+			css: (t, u) => ``
 		};
 	}
 </script>

--- a/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/+assets/app-b/src/lib/App.svelte
@@ -7,15 +7,15 @@
 	function spin(node, { duration }) {
 		return {
 			duration,
-			css: (t) => {
+			css: (t, u) => {
 				const eased = elasticOut(t);
 
 				return `
 					transform: scale(${eased}) rotate(${eased * 1080}deg);
 					color: hsl(
 						${Math.trunc(t * 360)},
-						${Math.min(100, 1000 * (1 - t))}%,
-						${Math.min(50, 500 * (1 - t))}%
+						${Math.min(100, 1000 * u)}%,
+						${Math.min(50, 500 * u)}%
 					);`;
 			}
 		};

--- a/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/09-transitions/04-custom-css-transitions/index.md
@@ -53,15 +53,15 @@ We can get a lot more creative though. Let's make something truly gratuitous:
 	function spin(node, { duration }) {
 		return {
 			duration,
-			css: t => +++{
+			css: (t, u) => +++{
 				const eased = elasticOut(t);
 
 				return `
 					transform: scale(${eased}) rotate(${eased * 1080}deg);
 					color: hsl(
 						${Math.trunc(t * 360)},
-						${Math.min(100, 1000 * (1 - t))}%,
-						${Math.min(50, 500 * (1 - t))}%
+						${Math.min(100, 1000 * u)}%,
+						${Math.min(50, 500 * u)}%
 					);`
 			}+++
 		};


### PR DESCRIPTION
### A note on documentation PRs

Currently [this page](https://svelte.dev/tutorial/svelte/custom-css-transitions) of tutorial speaks how function receives two arguments, `t` and `u` where `u = 1 - t` but them proceeds to use `1-t`.


This is not much but an honest fix.


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
