### PR TITLE
docs: Fixed TODO id in animation tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-a/src/lib/App.svelte
@@ -2,13 +2,15 @@
 	import TodoList from './TodoList.svelte';
 
 	const todos = $state([
-		{ done: false, description: 'write some docs' },
-		{ done: false, description: 'start writing blog post' },
-		{ done: true, description: 'buy some milk' },
-		{ done: false, description: 'mow the lawn' },
-		{ done: false, description: 'feed the turtle' },
-		{ done: false, description: 'fix some bugs' }
+		{ id: 1, done: false, description: 'write some docs' },
+		{ id: 2, done: false, description: 'start writing blog post' },
+		{ id: 3, done: true, description: 'buy some milk' },
+		{ id: 4, done: false, description: 'mow the lawn' },
+		{ id: 5, done: false, description: 'feed the turtle' },
+		{ id: 6, done: false, description: 'fix some bugs' }
 	]);
+
+	let uid = todos.length + 1;
 
 	function remove(todo) {
 		const index = todos.indexOf(todo);
@@ -23,6 +25,7 @@
 			if (e.key !== 'Enter') return;
 
 			todos.push({
+				id: uid++,
 				done: false,
 				description: e.currentTarget.value
 			});

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-a/src/lib/TodoList.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-a/src/lib/TodoList.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <ul class="todos">
-	{#each todos as todo (todo)}
+	{#each todos as todo (todo.id)}
 		<li
 			class={{ done: todo.done }}
 		>

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-b/src/lib/TodoList.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/01-deferred-transitions/+assets/app-b/src/lib/TodoList.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <ul class="todos">
-	{#each todos as todo (todo)}
+	{#each todos as todo (todo.id)}
 		<li
 			class={{ done: todo.done }}
 			in:receive={{ key: todo.id }}

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/02-animations/+assets/app-b/src/lib/TodoList.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/05-advanced-transitions/02-animations/+assets/app-b/src/lib/TodoList.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <ul class="todos">
-	{#each todos as todo (todo)}
+	{#each todos as todo (todo.id)}
 		<li
 			class={{ done: todo.done }}
 			in:receive={{ key: todo.id }}


### PR DESCRIPTION
The tutorial on advanced animations (see [this](https://svelte.dev/tutorial/svelte/deferred-transitions) and [this](https://svelte.dev/tutorial/svelte/animations)) is using `todo.id` without ever defining `id`.

For example, in TodoList.svelte, it says:

```svelte
<li
  class={{ done: todo.done }}
  in:receive={{ key: todo.id }}
  out:send={{ key: todo.id }}
>
```

However, the todos are defined in App.svelte like this:

```svelte
const todos = $state([
  { done: false, description: 'write some docs' },
  { done: false, description: 'start writing blog post' },
  { done: true, description: 'buy some milk' },
  { done: false, description: 'mow the lawn' },
  { done: false, description: 'feed the turtle' },
  { done: false, description: 'fix some bugs' }
]);
```

This PR adds the `id` to the todos, and also uses the id as the key in the #each loop.

Incrementing the `id` for new todos could be done in many ways, but I chose the `uid++` way to be consistent with [this example](https://github.com/sveltejs/svelte.dev/blob/1118cedd6906a3e52b89391a0c123f44e78cbd54/apps/svelte.dev/content/examples/10-animations/00-animate/%2Bassets/App.svelte#L36).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
