### PR TITLE
feat: Remove Rich Harris as commenter on preview comments

### DIFF
--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -1,11 +1,27 @@
 name: Docs preview create
 
 on:
-  repository_dispatch:
-    types: [docs-preview-create]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package name'
+        required: true
+        type: string
+      pr:
+        description: 'PR number'
+        required: true
+        type: string
+      owner:
+        description: 'Owner (eg. sveltejs)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch (eg. my-feature-branch)'
+        required: true
+        type: string
 
 env:
-  BRANCH: preview-${{ github.event.client_payload.package }}-${{ github.event.client_payload.pr }}
+  BRANCH: preview-${{ inputs.package }}-${{ inputs.pr }}
 
 jobs:
   Sync:
@@ -25,7 +41,7 @@ jobs:
         run: git fetch origin ${{ env.BRANCH }} && git checkout ${{ env.BRANCH }} || git checkout -b ${{ env.BRANCH }}
 
       - name: Sync
-        run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ github.event.client_payload.owner }}" -p "${{ github.event.client_payload.package }}#${{ github.event.client_payload.branch }}"
+        run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ inputs.owner }}" -p "${{ inputs.package }}#${{ inputs.branch }}"
 
       - name: Configure Git
         run: |

--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -3,8 +3,8 @@ name: Docs preview create
 on:
   workflow_dispatch:
     inputs:
-      package:
-        description: 'Package name'
+      repo:
+        description: 'Repository name (not fully-qualified, eg. `svelte` or `kit`)'
         required: true
         type: string
       pr:
@@ -21,11 +21,11 @@ on:
         type: string
 
 env:
-  BRANCH: preview-${{ inputs.package }}-${{ inputs.pr }}
+  BRANCH: preview-${{ inputs.repo }}-${{ inputs.pr }}
 
 jobs:
   Sync:
-    name: Sync (preview-${{ inputs.package }}-${{ inputs.pr }})
+    name: Sync
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
         run: git fetch origin ${{ env.BRANCH }} && git checkout ${{ env.BRANCH }} || git checkout -b ${{ env.BRANCH }}
 
       - name: Sync
-        run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ inputs.owner }}" -p "${{ inputs.package }}#${{ inputs.branch }}"
+        run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ inputs.owner }}" -p "${{ inputs.repo }}#${{ inputs.branch }}"
 
       - name: Configure Git
         run: |
@@ -52,3 +52,13 @@ jobs:
       - name: Push
         id: push
         run: git add -A && git commit -m "sync docs" && git push -u origin ${{ env.BRANCH }}
+
+      - name: Request preview comment
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: 'request-preview-comment'
+          client-payload: |-
+            {
+              "repo": "${{ inputs.repo }}",
+              "pr": "${{ inputs.pr }}",
+            }

--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -35,26 +35,3 @@ jobs:
       - name: Push
         id: push
         run: git add -A && git commit -m "sync docs" && git push -u origin ${{ env.BRANCH }}
-
-      - name: Find comment
-        id: fc
-        uses: peter-evans/find-comment@v3
-        with:
-          token: ${{ secrets.COMMENTER_TOKEN }}
-          repository: ${{ github.event.client_payload.repo }}
-          issue-number: ${{ github.event.client_payload.pr }}
-          comment-author: 'Rich-Harris' # it's using my personal access token, not sure if there's a way to comment as a bot instead
-          body-includes: _this is an automated message_
-
-      - name: Create comment
-        if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ secrets.COMMENTER_TOKEN }}
-          repository: ${{ github.event.client_payload.repo }}
-          issue-number: ${{ github.event.client_payload.pr }}
-          body: |
-            preview: https://svelte-dev-git-${{ env.BRANCH }}-svelte.vercel.app/
-
-            _this is an automated message_
-          edit-mode: replace

--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   Sync:
+    name: Sync (preview-${{ inputs.package }}-${{ inputs.pr }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs-preview-delete.yml
+++ b/.github/workflows/docs-preview-delete.yml
@@ -1,11 +1,19 @@
 name: Docs preview delete
 
 on:
-  repository_dispatch:
-    types: [docs-preview-delete]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package name'
+        required: true
+        type: string
+      pr:
+        description: 'PR number'
+        required: true
+        type: string
 
 env:
-  BRANCH: preview-${{ github.event.client_payload.package }}-${{ github.event.client_payload.pr }}
+  BRANCH: preview-${{ inputs.package }}-${{ inputs.pr }}
 
 jobs:
   Sync:

--- a/.github/workflows/docs-preview-delete.yml
+++ b/.github/workflows/docs-preview-delete.yml
@@ -3,8 +3,8 @@ name: Docs preview delete
 on:
   workflow_dispatch:
     inputs:
-      package:
-        description: 'Package name'
+      repo:
+        description: 'Repository name (not fully-qualified, eg. `svelte` or `kit`)'
         required: true
         type: string
       pr:
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  BRANCH: preview-${{ inputs.package }}-${{ inputs.pr }}
+  BRANCH: preview-${{ inputs.repo }}-${{ inputs.pr }}
 
 jobs:
   Sync:

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,8 +1,12 @@
 name: Sync docs
 
 on:
-  repository_dispatch:
-    types: [sync-request]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package name'
+        required: true
+        type: string
 
 jobs:
   Sync:
@@ -17,13 +21,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Sync
-        run: cd apps/svelte.dev && pnpm sync-docs -p ${{ github.event.client_payload.package }}
+        run: cd apps/svelte.dev && pnpm sync-docs -p ${{ inputs.package }}
 
       - name: Create or update pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: sync ${{ github.event.client_payload.package }} docs
-          title: Sync `${{ github.event.client_payload.package }}` docs
+          commit-message: sync ${{ inputs.package }} docs
+          title: Sync `${{ inputs.package }}` docs
           body: This is an automated pull request. See the [README](../tree/main/apps/svelte.dev/scripts/sync-docs/README.md) for more information
-          branch: sync-${{ github.event.client_payload.package }}
+          branch: sync-${{ inputs.package }}
           base: main

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -3,8 +3,8 @@ name: Sync docs
 on:
   workflow_dispatch:
     inputs:
-      package:
-        description: 'Package name'
+      repo:
+        description: 'Repository name (not fully-qualified, eg. `svelte` or `kit`)'
         required: true
         type: string
 
@@ -21,13 +21,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Sync
-        run: cd apps/svelte.dev && pnpm sync-docs -p ${{ inputs.package }}
+        run: cd apps/svelte.dev && pnpm sync-docs -p ${{ inputs.repo }}
 
       - name: Create or update pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: sync ${{ inputs.package }} docs
-          title: Sync `${{ inputs.package }}` docs
+          commit-message: sync ${{ inputs.repo }} docs
+          title: Sync `${{ inputs.repo }}` docs
           body: This is an automated pull request. See the [README](../tree/main/apps/svelte.dev/scripts/sync-docs/README.md) for more information
-          branch: sync-${{ inputs.package }}
+          branch: sync-${{ inputs.repo }}
           base: main


### PR DESCRIPTION
He doesn't deserve the power

This switches the workflows to `workflow_dispatch` triggers, which will also let us manually start them from the Actions interface if we ever need to.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
