### PR TITLE
feat: Add concurrency to docs-preview-create.yml

### DIFF
--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -27,6 +27,11 @@ jobs:
   Sync:
     name: Sync
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: preview-${{ inputs.repo }}-${{ inputs.pr }} # can't reference env here
+      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
I'm adding requests to create docs on pushes (so that PRs stay up to date if they add changes to docs later). This just makes sure that if someone pushes to the same PR a bunch of times, we don't run a bunch of concurrent jobs.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
