### PR TITLE
allow branch playground urls

### DIFF
--- a/packages/editor/src/lib/compile-worker/worker.ts
+++ b/packages/editor/src/lib/compile-worker/worker.ts
@@ -16,7 +16,7 @@ let can_use_experimental_async = false;
 
 async function init(v: string) {
 	const svelte_url = v === 'local' ? '/svelte' : `https://unpkg.com/svelte@${v}`;
-	const match = /^(?:pr|commit)-(.+)/.exec(v);
+	const match = /^(?:pr|commit|branch)-(.+)/.exec(v);
 
 	let tarball: FileDescription[] | undefined;
 	let version: string;

--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -34,7 +34,7 @@ let inited = Promise.withResolvers<typeof svelte>();
 let can_use_experimental_async = false;
 
 async function init(v: string, packages_url: string) {
-	const match = /^(pr|commit)-(.+)/.exec(v);
+	const match = /^(pr|commit|branch)-(.+)/.exec(v);
 
 	let tarball: FileDescription[] | undefined;
 


### PR DESCRIPTION
this was already possible before — the regex is pretty dumb, so `pr-<branch>` and `commit-<branch>` also work — but this PR formalises it