### PR TITLE
docs:Update App.svelte in Clock example according new rune syntax

### DIFF
--- a/apps/svelte.dev/content/examples/12-svg/01-clock/+assets/App.svelte
+++ b/apps/svelte.dev/content/examples/12-svg/01-clock/+assets/App.svelte
@@ -4,7 +4,7 @@
 	let time = $state(new Date());
 
 	// these automatically update when `time`
-	// changes, because of the `$:` prefix
+	// changes, because of the $derived
 	let hours = $derived(time.getHours());
 	let minutes = $derived(time.getMinutes());
 	let seconds = $derived(time.getSeconds());


### PR DESCRIPTION
Current example doesn't have legacy "$:" syntax. The comment is misleading. 