### PR TITLE
fix: correct redirection for examples/[...path]

### DIFF
--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -61,6 +61,11 @@ export async function handle({ event, resolve }) {
 		redirect(307, event.url.pathname.replace('/repl', '/playground'));
 	}
 
+	// For examples
+	if (event.url.pathname.startsWith('/examples')) {
+		redirect(307, event.url.pathname.replace('/examples', '/playground'));
+	}
+
 	// Best effort to redirect from Svelte 3 tutorial to new tutorial
 	if (event.url.pathname.startsWith('/tutorial/') && event.url.pathname.split('/').length === 2) {
 		redirect(307, event.url.pathname.replace('/tutorial/', '/tutorial/svelte/'));

--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -55,8 +55,8 @@ export async function handle({ event, resolve }) {
 		redirect(307, destination);
 	}
 
-	// For REPL. In SvelteKit, redirects can also be handled in +page.server.js,
-	// for example, see routes/examples/[...path]/+page.server.ts file.
+	// For REPL. For some reason, the repl/+page.server.ts file is not working, so
+	// we are doing the redirect here
 	if (event.url.pathname.startsWith('/repl')) {
 		redirect(307, event.url.pathname.replace('/repl', '/playground'));
 	}

--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -55,8 +55,8 @@ export async function handle({ event, resolve }) {
 		redirect(307, destination);
 	}
 
-	// For REPL. For some reason, the repl/+page.server.ts file is not working, so
-	// we are doing the redirect here
+	// For REPL. In SvelteKit, redirects can also be handled in +page.server.js,
+	// for example, see routes/examples/[...path]/+page.server.ts file.
 	if (event.url.pathname.startsWith('/repl')) {
 		redirect(307, event.url.pathname.replace('/repl', '/playground'));
 	}

--- a/apps/svelte.dev/src/routes/examples/[...path]/+page.server.ts
+++ b/apps/svelte.dev/src/routes/examples/[...path]/+page.server.ts
@@ -1,5 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 
+export const prerender = false;
+
 export function load({ url }) {
-	throw redirect(307, url.href.replace('/examples', '/playground'));
+	redirect(307, url.href.replace('/examples', '/playground'));
 }

--- a/apps/svelte.dev/src/routes/examples/[...path]/+page.server.ts
+++ b/apps/svelte.dev/src/routes/examples/[...path]/+page.server.ts
@@ -1,7 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-export const prerender = false;
-
-export function load({ url }) {
-	redirect(307, url.href.replace('/examples', '/playground'));
-}


### PR DESCRIPTION
### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

---

fixes #1129 .

The following need to be checked on the preview site:
- `/examples` redirects to `/playground`
- `/examples/hello-world` redirects to `/playground/hello-world`
- `/examples/thumbnails/actions.jpg` is not redirected
