### PR TITLE
docs: clarify the use of `throw` and `redirect`

### DIFF
--- a/apps/svelte.dev/content/tutorial/03-sveltekit/09-errors-and-redirects/04-redirects/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/09-errors-and-redirects/04-redirects/index.md
@@ -2,7 +2,7 @@
 title: Redirects
 ---
 
-We can also use the `throw` mechanism to redirect from one page to another.
+We can also use the `redirect` which uses `throw` internally to redirect from one page to another.
 
 Create a new `load` function in `src/routes/a/+page.server.js`:
 


### PR DESCRIPTION
### A note on documentation PRs
closes #1083


If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
