### PR TITLE
fix: diff highlighting for specific example in tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/+assets/app-a/src/lib/Stepper.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/+assets/app-a/src/lib/Stepper.svelte
@@ -1,5 +1,4 @@
 <script>
-	let {} = $props();
 </script>
 
 <button>-1</button>

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/+assets/app-a/src/lib/Stepper.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/+assets/app-a/src/lib/Stepper.svelte
@@ -1,4 +1,5 @@
 <script>
+	let {} = $props();
 </script>
 
 <button>-1</button>

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
@@ -7,7 +7,7 @@ You can pass event handlers to components like any other prop. In `Stepper.svelt
 ```svelte
 /// file: Stepper.svelte
 <script>
-	+++let { increment, decrement } = $props();+++
+	let +++{ increment, decrement }+++ = $props();
 </script>
 ```
 

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
@@ -7,7 +7,7 @@ You can pass event handlers to components like any other prop. In `Stepper.svelt
 ```svelte
 /// file: Stepper.svelte
 <script>
-	let { +++increment, decrement+++ } = $props();
+	+++let { increment, decrement } = $props();+++
 </script>
 ```
 

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
@@ -22,6 +22,7 @@ You can pass event handlers to components like any other prop. In `Stepper.svelt
 In `App.svelte`, define the handlers:
 
 ```svelte
+/// file: App.svelte
 <Stepper
 	+++increment={() => value += 1}+++
 	+++decrement={() => value -= 1}+++


### PR DESCRIPTION
### Not all the new code is highlighted in the code example
|How it was|How it is now|
|-|-|
|<img width="439" alt="Снимок экрана 2025-02-04 в 11 49 53" src="https://github.com/user-attachments/assets/76d8da64-21bd-471c-8570-a5475d0fcea8" />|<img width="450" alt="Снимок экрана 2025-02-04 в 11 50 00" src="https://github.com/user-attachments/assets/4315e30e-2d1c-4158-b75c-def2f5acd484" />|

The markdown renderer doesn't highlight full diff if it starts in the middle of another span (diff highlighting conflicts with language highlighting). So, ", decrement" is not highlighted because of this bug, it looks a little annoying to me.
Without working on renderer itself we can make it look better and just go around the bug