### PR TITLE
docs: Fixed old reference to throwing redirects in SvelteKit tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/03-sveltekit/09-errors-and-redirects/04-redirects/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/09-errors-and-redirects/04-redirects/index.md
@@ -2,7 +2,7 @@
 title: Redirects
 ---
 
-We can also use the `throw` mechanism to redirect from one page to another.
+We can use the `redirect` mechanism to redirect from one page to another.
 
 Create a new `load` function in `src/routes/a/+page.server.js`:
 


### PR DESCRIPTION
This is remaining work from [the tutorial update from SvelteKit 1 to 2](https://github.com/sveltejs/svelte.dev/commit/1fc5055f0f0aca9cc4611900c7d2494512cb088e#diff-bf2d1cf2d0668155a5de372c1a78a12e766e3a6f51ac7aa552c2771c24564c27). This fixes a remaining mention of `throw`ing `redirect`s on the [redirects tutorial step](https://svelte.dev/tutorial/kit/redirects).

> We can also use the throw mechanism to redirect from one page to another.

This PR is for the tutorial, which is maintained in this svelte.dev repo, not the docs in the sveltekit repo.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
