### PR TITLE
fix: text wrapping for page content

### DIFF
--- a/apps/svelte.dev/src/routes/docs/[...path]/+layout.svelte
+++ b/apps/svelte.dev/src/routes/docs/[...path]/+layout.svelte
@@ -27,6 +27,16 @@
 		padding: var(--sk-page-padding-top) var(--sk-page-padding-side) var(--sk-page-padding-bottom);
 
 		min-width: 0 !important;
+		overflow-wrap: break-word;
+		word-wrap: break-word;
+		word-break: break-word;
+	}
+
+	.page :global(h1) {
+		max-width: 100%;
+		overflow-wrap: break-word;
+		word-wrap: break-word;
+		hyphens: auto;
 	}
 
 	.page :global(:where(h2, h3) code) {


### PR DESCRIPTION
fixed weird text wrapping for long h1s in page content, refer the screenshots (before fix):

![image](https://github.com/user-attachments/assets/059edf66-0abf-4061-aaa6-63b010b41b93)
![image](https://github.com/user-attachments/assets/5d9e1dae-3c01-41e7-bf3a-3a7f6203329e)
![image](https://github.com/user-attachments/assets/05f24c6c-5297-4719-be8a-b08a98db2d86)

after fix:

<img width="970" alt="image" src="https://github.com/user-attachments/assets/63638e28-6783-4ec1-acc0-f4e1242a5c82" />
<img width="365" alt="image" src="https://github.com/user-attachments/assets/31f80e89-0466-4bca-82fd-66bd07233582" />



also properly wrapping of text is taken care with `word-break: break-word`.


### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
