### PR TITLE
docs: (Tutorial) Change spread and reassignment to .push()

### DIFF
--- a/apps/svelte.dev/content/tutorial/03-sveltekit/06-forms/05-customizing-use-enhance/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/06-forms/05-customizing-use-enhance/index.md
@@ -87,7 +87,7 @@ In the case of deletions, we don't really need to wait for the server to validat
 				method="POST"
 				action="?/delete"
 				+++use:enhance={() => {
-					deleting = [...deleting, todo.id];
+					deleting.push(todo.id)
 					return async ({ update }) => {
 						await update();
 						deleting = deleting.filter((id) => id !== todo.id);


### PR DESCRIPTION
Svelte 5 now uses a runtime reactivity system, so no need to use the Svelte 4 workaround of spreading and reassigning anymore.

I'm debating whether we should also change the filter to a findIndex + splice, like technically it would save the need of allocating a new array, but it seems like a big change comparing to a simple change to .push()

I love Svelte, I'm doing the tutorial again to keep up to date with Svelte 5 & SvelteKit features.

This is my first ever PR, sorry if I did something wrong, please let me know and I will try my best to fix it!

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
