### PR TITLE
docs: Added docs link for March 2025 What's New - server route resolu…

### DIFF
--- a/apps/svelte.dev/content/blog/2025-03-01-whats-new-in-svelte-march-2025.md
+++ b/apps/svelte.dev/content/blog/2025-03-01-whats-new-in-svelte-march-2025.md
@@ -13,7 +13,7 @@ But before we dive into that, let's get to some updates!
 
 - Native support for Websockets in SvelteKit is now available for testing! You can install the version of SvelteKit from the PR using pkg.pr.new and the PR number ([How To Install](https://github.com/sveltejs/kit/issues/1491#issuecomment-2645962690), [PR/Docs](https://github.com/sveltejs/kit/pull/12973))
 - `$props.id()` provides SSR-safe ID generation - unique for each instance of a component (**Svelte@5.20.0**, [Docs](</docs/svelte/$props#$props.id()>), [#15185](https://github.com/sveltejs/svelte/pull/15185))
-- SvelteKit now supports an option for server-side route resolution. This means that instead of loading the whole routing manifest in the client, and doing the route resolution there, the server runtime is invoked for each route request (**Kit@2.17.0**, [#13379](https://github.com/sveltejs/kit/pull/13379))
+- SvelteKit now supports an option for server-side route resolution. This means that instead of loading the whole routing manifest in the client, and doing the route resolution there, the server runtime is invoked for each route request (**Kit@2.17.0**, [Docs](</docs/kit/configuration#router>), [#13379](https://github.com/sveltejs/kit/pull/13379))
 - The values for `cache-control` and `content-type` headers are now validated in dev mode to help catch invalid values early (**2.17.0**, [#13114](https://github.com/sveltejs/kit/pull/13114))
 
 For a full list of bug fixes in Svelte, SvelteKit and its adapters, check out their CHANGELOGs [here](https://github.com/sveltejs/svelte/blob/main/packages/svelte/CHANGELOG.md) and [here](https://github.com/sveltejs/kit/tree/main/packages).

--- a/apps/svelte.dev/content/blog/2025-03-01-whats-new-in-svelte-march-2025.md
+++ b/apps/svelte.dev/content/blog/2025-03-01-whats-new-in-svelte-march-2025.md
@@ -13,7 +13,7 @@ But before we dive into that, let's get to some updates!
 
 - Native support for Websockets in SvelteKit is now available for testing! You can install the version of SvelteKit from the PR using pkg.pr.new and the PR number ([How To Install](https://github.com/sveltejs/kit/issues/1491#issuecomment-2645962690), [PR/Docs](https://github.com/sveltejs/kit/pull/12973))
 - `$props.id()` provides SSR-safe ID generation - unique for each instance of a component (**Svelte@5.20.0**, [Docs](</docs/svelte/$props#$props.id()>), [#15185](https://github.com/sveltejs/svelte/pull/15185))
-- SvelteKit now supports an option for server-side route resolution. This means that instead of loading the whole routing manifest in the client, and doing the route resolution there, the server runtime is invoked for each route request (**Kit@2.17.0**, [Docs](</docs/kit/configuration#router>), [#13379](https://github.com/sveltejs/kit/pull/13379))
+- SvelteKit now supports an option for server-side route resolution. This means that instead of loading the whole routing manifest in the client, and doing the route resolution there, the server runtime is invoked for each route request (**Kit@2.17.0**, [docs](/docs/kit/configuration#router), [pull request](https://github.com/sveltejs/kit/pull/13379))
 - The values for `cache-control` and `content-type` headers are now validated in dev mode to help catch invalid values early (**2.17.0**, [#13114](https://github.com/sveltejs/kit/pull/13114))
 
 For a full list of bug fixes in Svelte, SvelteKit and its adapters, check out their CHANGELOGs [here](https://github.com/sveltejs/svelte/blob/main/packages/svelte/CHANGELOG.md) and [here](https://github.com/sveltejs/kit/tree/main/packages).


### PR DESCRIPTION
Added the docs link for SvelteKit [#13379](https://github.com/sveltejs/kit/pull/13379) for consistency with other "What's New" changes and news.  The docs links for changes covered in the Svelte newsletter and blog updates are extremely useful and help make Svelte's community docs so awesome!

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
