### PR TITLE
fix: adjust right padding in OnThisPage component to fix text overflow

### DIFF
--- a/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
+++ b/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
@@ -217,7 +217,11 @@
 				overflow-y: auto;
 				scrollbar-width: none;
 				margin-left: -1rem; /* negative margin avoids focus rings being cut off */
-				padding: 0 1rem var(--sk-page-padding-top) 1rem;
+				padding: 0 var(--sk-page-padding-side) var(--sk-page-padding-top) 1rem;
+
+				li {
+					text-indent: 1ch hanging;
+				}
 
 				li:first-child {
 					display: list-item;

--- a/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
+++ b/apps/svelte.dev/src/routes/docs/[...path]/OnThisPage.svelte
@@ -217,7 +217,7 @@
 				overflow-y: auto;
 				scrollbar-width: none;
 				margin-left: -1rem; /* negative margin avoids focus rings being cut off */
-				padding: 0 0 var(--sk-page-padding-top) 1rem;
+				padding: 0 1rem var(--sk-page-padding-top) 1rem;
 
 				li:first-child {
 					display: list-item;


### PR DESCRIPTION
### Issue Reference

Fixes [#1183](https://github.com/sveltejs/svelte.dev/issues/1183)

On certain screen resolutions and specific pages, the "On This Page" navigation text appears to overflow or sit too close to the container edge. 
### Description of Changes

- Added a right padding of `1rem` to the "On This Page" navigation container.
- This ensures proper spacing and improves readability, preventing text from appearing too close to or overflowing the container edge.

### Screenshots

| Before                                                                                       | After                                                                                        |
| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| ![Before fix](https://github.com/user-attachments/assets/6a118b27-d286-4d07-bd12-cfe93225fdfa) | ![After fix](https://github.com/user-attachments/assets/bae1c844-a48b-4948-aee0-1a72215e2fdf) |
