### PR TITLE
Tailwind

### DIFF
--- a/apps/svelte.dev/src/lib/tutorial/adapters/rollup/index.svelte.ts
+++ b/apps/svelte.dev/src/lib/tutorial/adapters/rollup/index.svelte.ts
@@ -45,7 +45,7 @@ export async function create(): Promise<Adapter> {
 				.filter((f): f is File => f.name.startsWith('/src/lib/') && f.type === 'file')
 				.map((f) => ({ ...f, name: f.name.slice(9) })),
 			{
-				runes: true
+				// TODO support Tailwind here?
 			}
 		);
 	}

--- a/packages/editor/src/lib/Workspace.svelte.ts
+++ b/packages/editor/src/lib/Workspace.svelte.ts
@@ -113,6 +113,7 @@ export class Workspace {
 	#files = $state.raw<Item[]>([]);
 	#current = $state.raw() as File;
 	#vim = $state(false);
+	#tailwind = $state(false);
 
 	#handlers = {
 		hover: new Set<(pos: number | null) => void>(),
@@ -462,6 +463,15 @@ export class Workspace {
 		if (state) {
 			this.#update_state(file, state);
 		}
+	}
+
+	get tailwind() {
+		return this.#tailwind;
+	}
+
+	set tailwind(value) {
+		this.#tailwind = value;
+		this.#onreset(this.#files);
 	}
 
 	get vim() {

--- a/packages/editor/src/lib/compile-worker/worker.ts
+++ b/packages/editor/src/lib/compile-worker/worker.ts
@@ -59,7 +59,6 @@ async function init(v: string) {
 
 		can_use_experimental_async = true;
 	} catch (e) {
-		console.error(e);
 		// do nothing
 	}
 

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -86,6 +86,7 @@
 		"marked": "^14.1.2",
 		"resolve.exports": "^2.0.2",
 		"svelte": "5.23.0",
+		"tailwindcss": "^4.0.15",
 		"tarparser": "^0.0.4",
 		"zimmerframe": "^1.1.2"
 	}

--- a/packages/repl/src/lib/Bundler.ts
+++ b/packages/repl/src/lib/Bundler.ts
@@ -58,7 +58,7 @@ export default class Bundler {
 		});
 	}
 
-	bundle(files: File[], options: { tailwind: boolean }): Promise<BundleResult> {
+	bundle(files: File[], options: { tailwind?: boolean }): Promise<BundleResult> {
 		return new Promise<any>((fulfil) => {
 			this.handlers.set(uid, fulfil);
 			this.worker.postMessage({

--- a/packages/repl/src/lib/Bundler.ts
+++ b/packages/repl/src/lib/Bundler.ts
@@ -58,7 +58,7 @@ export default class Bundler {
 		});
 	}
 
-	bundle(files: File[], options: CompileOptions = {}): Promise<BundleResult> {
+	bundle(files: File[], options: { tailwind: boolean }): Promise<BundleResult> {
 		return new Promise<any>((fulfil) => {
 			this.handlers.set(uid, fulfil);
 			this.worker.postMessage({

--- a/packages/repl/src/lib/Input/ComponentSelector.svelte
+++ b/packages/repl/src/lib/Input/ComponentSelector.svelte
@@ -170,6 +170,11 @@
 				<Checkbox bind:checked={workspace.vim}></Checkbox>
 			</label>
 
+			<label class="option">
+				<span>Toggle Tailwind</span>
+				<Checkbox bind:checked={workspace.tailwind}></Checkbox>
+			</label>
+
 			<button disabled={!can_migrate} onclick={migrate}>Migrate to Svelte 5, if possible</button>
 
 			{#if download}

--- a/packages/repl/src/lib/Output/ReplProxy.ts
+++ b/packages/repl/src/lib/Output/ReplProxy.ts
@@ -85,8 +85,8 @@ export default class ReplProxy {
 		}
 	}
 
-	eval(script: string) {
-		return this.iframe_command('eval', { script });
+	eval(script: string, style?: string) {
+		return this.iframe_command('eval', { script, style });
 	}
 
 	handle_links() {

--- a/packages/repl/src/lib/Output/Viewer.svelte
+++ b/packages/repl/src/lib/Output/Viewer.svelte
@@ -8,6 +8,7 @@
 	import Console, { type Log } from './console/Console.svelte';
 	import getLocationFromStack from './get-location-from-stack';
 	import srcdoc from './srcdoc/index.html?raw';
+	import srcdoc_styles from './srcdoc/styles.css?raw';
 	import ErrorOverlay from './ErrorOverlay.svelte';
 	import type { CompileError } from 'svelte/compiler';
 	import type { Bundle } from '../types';
@@ -185,7 +186,7 @@
 					}
 					//# sourceURL=playground:output
 				`,
-					$bundle?.tailwind
+					$bundle?.tailwind ?? srcdoc_styles
 				);
 				error = null;
 			}

--- a/packages/repl/src/lib/Output/Viewer.svelte
+++ b/packages/repl/src/lib/Output/Viewer.svelte
@@ -107,7 +107,8 @@
 			clear_logs();
 
 			if (!$bundle.error) {
-				await proxy?.eval(`
+				await proxy?.eval(
+					`
 					${injectedJS}
 
 					if (!window.__setup_focus_handling) {
@@ -183,7 +184,9 @@
 						}
 					}
 					//# sourceURL=playground:output
-				`);
+				`,
+					$bundle?.tailwind
+				);
 				error = null;
 			}
 		} catch (e) {

--- a/packages/repl/src/lib/Output/console/Console.svelte
+++ b/packages/repl/src/lib/Output/console/Console.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 	export type Log = {
 		command: 'info' | 'warn' | 'error' | 'table' | 'group' | 'clear' | 'unclonable';
 		action?: 'console';

--- a/packages/repl/src/lib/Output/srcdoc/index.html
+++ b/packages/repl/src/lib/Output/srcdoc/index.html
@@ -1,72 +1,13 @@
 <!doctype html>
 <html>
 	<head>
-		<style>
-			body {
-				--bg-1: hsl(0, 0%, 100%);
-				--bg-2: hsl(206, 20%, 90%);
-				--bg-3: hsl(206, 20%, 80%);
-				--fg-1: hsl(0, 0%, 13%);
-				--fg-2: hsl(0, 0%, 20%);
-				--fg-2: hsl(0, 0%, 30%);
-				--link: hsl(208, 77%, 47%);
-				--link-hover: hsl(208, 77%, 55%);
-				--link-active: hsl(208, 77%, 40%);
-				--border-radius: 4px;
-				--font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-					'Open Sans', 'Helvetica Neue', sans-serif;
-				--font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas,
-					'DejaVu Sans Mono', monospace;
-				color-scheme: light;
-				background: var(--bg-1);
-				color: var(--fg-1);
-				font-family: var(--font);
-				line-height: 1.5;
-				margin: 1rem;
-				height: calc(100vh - 2rem);
-				accent-color: var(--hover) !important;
-			}
-
-			a {
-				color: var(--link);
-			}
-
-			a:hover {
-				color: var(--link-hover);
-			}
-
-			a:active {
-				color: var(--link-active);
-			}
-
-			code {
-				background: var(--bg-2);
-				font-family: var(--font-mono);
-				font-size: 0.9em;
-				padding: 0.15rem 0.3rem;
-				border-radius: var(--border-radius);
-			}
-
-			ul.todos {
-				padding: 0;
-			}
-
-			body.dark {
-				color-scheme: dark;
-				--bg-1: hsl(0, 0%, 18%);
-				--bg-2: hsl(0, 0%, 30%);
-				--bg-3: hsl(0, 0%, 40%);
-				--fg-1: hsl(0, 0%, 90%);
-				--fg-2: hsl(0, 0%, 70%);
-				--fg-3: hsl(0, 0%, 60%);
-				--link: hsl(206, 96%, 72%);
-				--link-hover: hsl(206, 96%, 78%);
-				--link-active: hsl(206, 96%, 64%);
-			}
-		</style>
+		<style id="injected"></style>
 
 		<script>
 			(function () {
+				const style = document.querySelector('style#injected');
+				let styles = '';
+
 				function send(payload, origin = '*') {
 					if (payload.command === 'info' && payload.args[0] instanceof Error) {
 						const error = payload.args[0];
@@ -97,6 +38,10 @@
 						}
 
 						if (action === 'eval') {
+							if (data.args.style !== undefined && styles !== (styles = data.args.style)) {
+								style.textContent = styles;
+							}
+
 							(0, eval)(data.args.script);
 						}
 

--- a/packages/repl/src/lib/Output/srcdoc/styles.css
+++ b/packages/repl/src/lib/Output/srcdoc/styles.css
@@ -1,0 +1,61 @@
+body {
+	--bg-1: hsl(0, 0%, 100%);
+	--bg-2: hsl(206, 20%, 90%);
+	--bg-3: hsl(206, 20%, 80%);
+	--fg-1: hsl(0, 0%, 13%);
+	--fg-2: hsl(0, 0%, 20%);
+	--fg-2: hsl(0, 0%, 30%);
+	--link: hsl(208, 77%, 47%);
+	--link-hover: hsl(208, 77%, 55%);
+	--link-active: hsl(208, 77%, 40%);
+	--border-radius: 4px;
+	--font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+		'Open Sans', 'Helvetica Neue', sans-serif;
+	--font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono',
+		monospace;
+	color-scheme: light;
+	background: var(--bg-1);
+	color: var(--fg-1);
+	font-family: var(--font);
+	line-height: 1.5;
+	margin: 1rem;
+	height: calc(100vh - 2rem);
+	accent-color: var(--hover) !important;
+}
+
+a {
+	color: var(--link);
+}
+
+a:hover {
+	color: var(--link-hover);
+}
+
+a:active {
+	color: var(--link-active);
+}
+
+code {
+	background: var(--bg-2);
+	font-family: var(--font-mono);
+	font-size: 0.9em;
+	padding: 0.15rem 0.3rem;
+	border-radius: var(--border-radius);
+}
+
+ul.todos {
+	padding: 0;
+}
+
+body.dark {
+	color-scheme: dark;
+	--bg-1: hsl(0, 0%, 18%);
+	--bg-2: hsl(0, 0%, 30%);
+	--bg-3: hsl(0, 0%, 40%);
+	--fg-1: hsl(0, 0%, 90%);
+	--fg-2: hsl(0, 0%, 70%);
+	--fg-3: hsl(0, 0%, 60%);
+	--link: hsl(206, 96%, 72%);
+	--link-hover: hsl(206, 96%, 78%);
+	--link-active: hsl(206, 96%, 64%);
+}

--- a/packages/repl/src/lib/Repl.svelte
+++ b/packages/repl/src/lib/Repl.svelte
@@ -95,7 +95,9 @@
 
 	async function rebundle() {
 		const token = (current_token = Symbol());
-		const result = await bundler!.bundle(workspace.files as File[]);
+		const result = await bundler!.bundle(workspace.files as File[], {
+			tailwind: workspace.tailwind
+		});
 		if (token === current_token) $bundle = result as Bundle;
 	}
 

--- a/packages/repl/src/lib/types.d.ts
+++ b/packages/repl/src/lib/types.d.ts
@@ -26,6 +26,7 @@ export type Bundle = {
 	client: OutputChunk | null;
 	error: (RollupError & CompileError) | null;
 	server: OutputChunk | null;
+	tailwind?: string;
 	imports: string[];
 	warnings: Warning[];
 };

--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -93,7 +93,6 @@ async function init(v: string, packages_url: string) {
 
 		can_use_experimental_async = true;
 	} catch (e) {
-		console.error(e);
 		// do nothing
 	}
 

--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -23,6 +23,10 @@ import type { Node } from 'estree';
 import { parseTar, type FileDescription } from 'tarparser';
 import { max } from './semver';
 
+import tailwind_preflight from 'tailwindcss/preflight.css?raw';
+import tailwind_theme from 'tailwindcss/theme.css?raw';
+import tailwind_utilities from 'tailwindcss/utilities.css?raw';
+
 // hack for magic-string and rollup inline sourcemaps
 // do not put this into a separate module and import it, would be treeshaken in prod
 self.window = self;
@@ -255,10 +259,6 @@ let previous: {
 let tailwind: Awaited<ReturnType<typeof init_tailwind>>;
 
 async function init_tailwind() {
-	const { default: tailwind_preflight } = await import('tailwindcss/preflight.css?raw');
-	const { default: tailwind_theme } = await import('tailwindcss/theme.css?raw');
-	const { default: tailwind_utilities } = await import('tailwindcss/utilities.css?raw');
-
 	const tailwind_files = {
 		'tailwindcss/theme.css': tailwind_theme,
 		'tailwindcss/preflight.css': tailwind_preflight,

--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -253,13 +253,13 @@ const versions = Object.create(null);
 
 let previous: {
 	key: string;
-	cache: RollupCache;
+	cache: RollupCache | undefined;
 };
 
 let tailwind: Awaited<ReturnType<typeof init_tailwind>>;
 
 async function init_tailwind() {
-	const tailwind_files = {
+	const tailwind_files: Record<string, string> = {
 		'tailwindcss/theme.css': tailwind_theme,
 		'tailwindcss/preflight.css': tailwind_preflight,
 		'tailwindcss/utilities.css': tailwind_utilities
@@ -292,7 +292,7 @@ async function get_bundle(
 	const warnings: Warning[] = [];
 	const all_warnings: Array<{ message: string }> = [];
 
-	const tailwind_candidates = [];
+	const tailwind_candidates: string[] = [];
 
 	function add_tailwind_candidates(ast: Node | undefined) {
 		if (!ast) return;

--- a/packages/repl/src/lib/workers/workers.d.ts
+++ b/packages/repl/src/lib/workers/workers.d.ts
@@ -48,6 +48,10 @@ export interface MigrateOutput {
 	error?: string;
 }
 
+export interface BundleOptions {
+	tailwind: boolean;
+}
+
 export type BundleMessageData = {
 	uid: number;
 	type: 'init' | 'bundle' | 'status' | 'error';
@@ -55,7 +59,7 @@ export type BundleMessageData = {
 	packages_url: string;
 	svelte_version: string;
 	files: File[];
-	options: CompileOptions;
+	options: BundleOptions;
 };
 
 declare global {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       svelte:
         specifier: 5.23.0
         version: 5.23.0
+      tailwindcss:
+        specifier: ^4.0.15
+        version: 4.0.15
       tarparser:
         specifier: ^0.0.4
         version: 0.0.4
@@ -3081,6 +3084,9 @@ packages:
   svelte@5.23.0:
     resolution: {integrity: sha512-v0lL3NuKontiCxholEiAXCB+BYbndlKbwlDMK0DS86WgGELMJSpyqCSbJeMEMBDwOglnS7Ar2Rq0wwa/z2L8Vg==}
     engines: {node: '>=18'}
+
+  tailwindcss@4.0.15:
+    resolution: {integrity: sha512-6ZMg+hHdMJpjpeCCFasX7K+U615U9D+7k5/cDK/iRwl6GptF24+I/AbKgOnXhVKePzrEyIXutLv36n4cRsq3Sg==}
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
@@ -5963,6 +5969,8 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.12
       zimmerframe: 1.1.2
+
+  tailwindcss@4.0.15: {}
 
   tar@7.4.3:
     dependencies:


### PR DESCRIPTION
We can now use Tailwind in the playground — just click the toggle:

<img width="257" alt="image" src="https://github.com/user-attachments/assets/98164d24-42a2-41ac-87b9-ec949ae23561" />

It probably makes sense to store the option along with the data (and in the hash, where applicable); am currently building this at a hackathon and may or may not get as far as that