### PR TITLE
fix rss.xml headers

### DIFF
--- a/apps/svelte.dev/src/routes/blog/rss.xml/+server.js
+++ b/apps/svelte.dev/src/routes/blog/rss.xml/+server.js
@@ -62,8 +62,7 @@ const get_rss = async (posts) => {
 export async function GET() {
 	return new Response(await get_rss(index.blog.children), {
 		headers: {
-			'Cache-Control': `max-age=${30 * 60 * 1e3}`,
-			'Content-Type': 'application/rss+xml'
+			'Content-Type': 'application/xml'
 		}
 	});
 }


### PR DESCRIPTION
small QOL fix — this allows `/blog/rss.xml` to open inline in the browser instead of triggering a download. For whatever reason `application/rss+xml`, while 'correct', yields unhelpful results.

The cache control header doesn't do anything since this route is prerendered, so I got rid of it.