### PR TITLE
remove console.clear

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -632,7 +632,6 @@ async function bundle({
 	options: BundleOptions;
 }) {
 	if (!DEV) {
-		console.clear();
 		console.log(`running Svelte compiler version %c${svelte.VERSION}`, 'font-weight: bold');
 	}
 


### PR DESCRIPTION
the playground is currently down, and it's hard to figure out why because the console gets cleared. we should probably just get rid of it