### PR TITLE
switch from unpkg to jsdelivr

### DIFF
--- a/apps/svelte.dev/src/lib/tutorial/adapters/rollup/index.svelte.ts
+++ b/apps/svelte.dev/src/lib/tutorial/adapters/rollup/index.svelte.ts
@@ -23,7 +23,7 @@ export async function create(): Promise<Adapter> {
 	let done = false;
 
 	bundler = new Bundler({
-		packages_url: 'https://unpkg.com',
+		packages_url: 'https://cdn.jsdelivr.net/npm',
 		svelte_version: 'latest',
 		onstatus(val) {
 			if (!done && val === null) {

--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
@@ -31,7 +31,7 @@
 
 	if (version !== 'local' && !is_pr_or_commit_version) {
 		$effect(() => {
-			fetch(`https://unpkg.com/svelte@${version}/package.json`)
+			fetch(`https://cdn.jsdelivr.net/npm/svelte@${version}/package.json`)
 				.then((r) => r.json())
 				.then((pkg) => {
 					if (pkg.version !== version) {

--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/embed/+page.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/embed/+page.svelte
@@ -17,7 +17,7 @@
 
 	if (version !== 'local' && !is_pr_or_commit_version) {
 		$effect(() => {
-			fetch(`https://unpkg.com/svelte@${version}/package.json`)
+			fetch(`https://cdn.jsdelivr.net/npm/svelte@${version}/package.json`)
 				.then((r) => r.json())
 				.then((pkg) => {
 					if (pkg.version !== data.version) {

--- a/packages/editor/src/lib/compile-worker/worker.ts
+++ b/packages/editor/src/lib/compile-worker/worker.ts
@@ -15,7 +15,7 @@ let inited: PromiseWithResolvers<typeof self.svelte>;
 let can_use_experimental_async = false;
 
 async function init(v: string) {
-	const svelte_url = v === 'local' ? '/svelte' : `https://unpkg.com/svelte@${v}`;
+	const svelte_url = v === 'local' ? '/svelte' : `https://cdn.jsdelivr.net/npm/svelte@${v}`;
 	const match = /^(?:pr|commit|branch)-(.+)/.exec(v);
 
 	let tarball: FileDescription[] | undefined;

--- a/packages/repl/src/lib/Repl.svelte
+++ b/packages/repl/src/lib/Repl.svelte
@@ -27,7 +27,7 @@
 	}
 
 	let {
-		packagesUrl = 'https://unpkg.com',
+		packagesUrl = 'https://cdn.jsdelivr.net/npm',
 		svelteVersion = 'latest',
 		embedded = false,
 		orientation = 'columns',

--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -588,7 +588,7 @@ async function get_bundle(
 						if (id === './__entry.js') return;
 						if (id === 'esm-env') return;
 						if (id === shared_file) return;
-						if (id.startsWith('https://unpkg.com/clsx@')) return;
+						if (id.startsWith('https://cdn.jsdelivr.net/npm/clsx@')) return;
 
 						add_tailwind_candidates(this.parse(code));
 					}


### PR DESCRIPTION
This replaces unpkg.com with jsdelivr.com, which is actively maintained and seems somewhat more robust (I've been experiencing a lot of issues with unpkg recently and I'm apparently not alone).

At least in local testing, jsDelivr also seems faster. However:

1. jsDelivr doesn't resolve directory imports. This means that a file like [this](https://cdn.jsdelivr.net/npm/radix-svelte@0.9.0/dist/index.js)...

```js
export * from './components';
```

...doesn't work, because it should be `./components/index.js`. Personally I'm not too concerned about this — packages should contain valid imports.

2. More concerningly, it doesn't always successfully resolve entry points. It can resolve [`svelte`](https://cdn.jsdelivr.net/npm/svelte) but not [`svelte/legacy`](https://cdn.jsdelivr.net/npm/svelte/legacy), for example — it doesn't appear to handle `pkg.exports` correctly. Appending `/+esm` to pathnames results in a 200 response, but not one we can use (it bundles stuff in a way that would break things).