### PR TITLE
fix: Remove <p>

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/01-contenteditable-bindings/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/01-contenteditable-bindings/+assets/app-a/src/lib/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	let html = $state('<p>Write some text!</p>');
+	let html = $state('Write some text!');
 </script>
 
 <div contenteditable></div>


### PR DESCRIPTION
The `<p>` tags render literally as `"<p> 'Write some text..."`

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
