### PR TITLE
docs: Improve explanation of 05-keyed-each-blocks in tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
@@ -2,7 +2,7 @@
 title: Keyed each blocks
 ---
 
-By default, when you modify the value of an `each` block, it will add and remove DOM nodes at the _end_ of the block, and update any values that have changed. That might not be what you want.
+By default, when you modify the iterable the `each` block displays, it will add or remove DOM nodes at the _end_ of the block, and update all nodes' values to reflect the modification. That might not be what you want.
 
 It's easier to show why than to explain. Inside `Thing.svelte`, `name` is a dynamic prop but `emoji` is a constant.
 
@@ -10,6 +10,8 @@ Click the 'Remove first thing' button a few times, and notice what happens:
 
 1. It removes the last component.
 2. It then updates the `name` value in the remaining DOM nodes, but not the emoji.
+
+To make it concrete, on the first iteration, Svelte removes the last DOM node ('Egg') and updates the remaining nodes to reflect the new data. 'Egg' takes the place of 'Doughnut', 'Doughnut' replaces 'Carrot, and so on. Because the emoji for each `<Thing>`'s DOM node was initialized at the beginning, with no dependence on state, each node's emoji remains unchanged.
 
 > [!NOTE] If you're coming from React, this might seem strange, because you're used to the entire component re-rendering when state changes. Svelte works differently: the component 'runs' once, and subsequent updates are 'fine-grained'. This makes things faster and gives you more control.
 

--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
@@ -2,16 +2,14 @@
 title: Keyed each blocks
 ---
 
-By default, when you modify the iterable the `each` block displays, it will add or remove DOM nodes at the _end_ of the block, and update all nodes' values to reflect the modification. That might not be what you want.
+By default, updating the value of an `each` block will add or remove DOM nodes at the _end_ of the block if the size changes, and update the remaining DOM. That might not be what you want.
 
 It's easier to show why than to explain. Inside `Thing.svelte`, `name` is a dynamic prop but `emoji` is a constant.
 
 Click the 'Remove first thing' button a few times, and notice what happens:
 
 1. It removes the last component.
-2. It then updates the `name` value in the remaining DOM nodes, but not the emoji.
-
-To make it concrete, on the first iteration, Svelte removes the last DOM node ('Egg') and updates the remaining nodes to reflect the new data. 'Egg' takes the place of 'Doughnut', 'Doughnut' replaces 'Carrot, and so on. Because the emoji for each `<Thing>`'s DOM node was initialized at the beginning, with no dependence on state, each node's emoji remains unchanged.
+2. It then updates the `name` value in the remaining DOM nodes (the text node containing 'doughnut' now contains 'egg', and so on), but not the emoji.
 
 > [!NOTE] If you're coming from React, this might seem strange, because you're used to the entire component re-rendering when state changes. Svelte works differently: the component 'runs' once, and subsequent updates are 'fine-grained'. This makes things faster and gives you more control.
 


### PR DESCRIPTION
I personally was confused with the previous explanation as to what it meant that the other list items were updated. Explaining it that egg replaced the name attribute for the doughnut, and doughnut replaced the name attribute for the car node, helped me understand what Svelte was actually doing. Explicitly drawing out what Svelte is doing made it make more sense, but I'm open to feedback! If this doesn't fit the style or is too verbose, I'll try to figure out something else! 

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
