### PR TITLE
fix: bug where 'time' was in plural when count is equal to 0

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/01-state/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/01-state/+assets/app-a/src/lib/App.svelte
@@ -8,5 +8,5 @@
 
 <button onclick={increment}>
 	Clicked {count}
-	{count === 1 ? 'time' : 'times'}
+	{count <= 1 ? 'time' : 'times'}
 </button>

--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/01-state/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/01-state/+assets/app-b/src/lib/App.svelte
@@ -8,5 +8,5 @@
 
 <button onclick={increment}>
 	Clicked {count}
-	{count === 1 ? 'time' : 'times'}
+	{count <= 1 ? 'time' : 'times'}
 </button>


### PR DESCRIPTION
While doing the course to learn Svelte I saw in the button : 'Clicked 0 times' that 'time' was in plural, and normally (except if something change in the English language) this isn't suppose to be the case.

Here is a screenshot of how it looked like before the fix :
![Screenshot from 2025-04-03 13-24-41](https://github.com/user-attachments/assets/2cdb130d-7d49-466b-9249-f65a4ef03ab1)

And after the fix :
[Screencast from 2025-04-03 13-26-45.webm](https://github.com/user-attachments/assets/797e3dd4-9769-4a06-8fe8-bdaf41d9b847)
