### PR TITLE
docs: Updated $effect tutorial text

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/05-effects/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/05-effects/index.md
@@ -41,7 +41,7 @@ $effect(() => {
 });
 ```
 
-The cleanup function is called immediately before the effect function re-runs when `interval` changes, and also when the component is destroyed.
+An effect can return a teardown function which will run immediately before the effect re-runs. That's why are returning the cleanup function here so the lastly created interval is properly removed. The cleanup function will also run when the component is destroyed.
 
 If the effect function doesn't read any state when it runs, it will only run once, when the component mounts.
 


### PR DESCRIPTION
Added more explanation to the $effect tutorial so it is more clear why we are returning function there.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
