### PR TITLE
squelch some warnings

### DIFF
--- a/apps/svelte.dev/src/lib/db/client.js
+++ b/apps/svelte.dev/src/lib/db/client.js
@@ -2,9 +2,7 @@ import { building } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import { createClient } from '@supabase/supabase-js';
 
-const enabled = !building && env.SUPABASE_URL && env.SUPABASE_KEY;
-
-if (!enabled) {
+if (!building && (!env.SUPABASE_URL || !env.SUPABASE_KEY)) {
 	console.warn(
 		`Missing SUPABASE_URL and SUPABASE_KEY environment variables. Loading and saving in the playground is disabled`
 	);
@@ -15,7 +13,7 @@ if (!enabled) {
  */
 // @ts-ignore-line
 export const client =
-	enabled &&
+	!building &&
 	createClient(env.SUPABASE_URL, env.SUPABASE_KEY, {
 		global: { fetch },
 		auth: { persistSession: false }

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/ImageViewer.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/ImageViewer.svelte
@@ -32,8 +32,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background: white
-			url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 20 20" height="20px" width="20px"><g><rect fill="hsl(240, 8%, 95%)" width="10" height="10"></rect><rect fill="hsl(240, 8%, 95%)" x="10" y="10" width="10" height="10"></rect></g></svg>');
+		background: white url('./image-viewer-background.svg');
 	}
 
 	img {

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/ImageViewer.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/ImageViewer.svelte
@@ -32,7 +32,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background: white url('./image-viewer-background.svg');
+		background: white url(./image-viewer-background.svg);
 	}
 
 	img {

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/image-viewer-background.svg
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/image-viewer-background.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 20 20" height="20px" width="20px"><g><rect fill="hsl(240, 8%, 95%)" width="10" height="10"></rect><rect fill="hsl(240, 8%, 95%)" x="10" y="10" width="10" height="10"></rect></g></svg>

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -1,5 +1,5 @@
 import MagicString from 'magic-string';
-import { createHash, Hash } from 'node:crypto';
+import { createHash, type Hash } from 'node:crypto';
 import fs from 'node:fs';
 import process from 'node:process';
 import path from 'node:path';

--- a/packages/site-kit/src/lib/markdown/utils.ts
+++ b/packages/site-kit/src/lib/markdown/utils.ts
@@ -1,4 +1,4 @@
-import { Marked, Renderer, type TokenizerObject, type MarkedExtension } from 'marked';
+import { Marked, type Renderer, type TokenizerObject, type MarkedExtension } from 'marked';
 import json5 from 'json5';
 
 export const SHIKI_LANGUAGE_MAP = {


### PR DESCRIPTION
fixes a few build-time warnings, and also fixes the `ImageViewer.svelte` background that's seen (or currently not seen, because it's broken) when you select an image file in e.g. https://svelte.dev/tutorial/svelte/svelte-body