### PR TITLE
default to runes mode in tutorial

### DIFF
--- a/apps/svelte.dev/src/lib/tutorial/adapters/rollup/index.svelte.ts
+++ b/apps/svelte.dev/src/lib/tutorial/adapters/rollup/index.svelte.ts
@@ -33,6 +33,7 @@ export async function create(): Promise<Adapter> {
 				.map((f) => ({ ...f, name: f.name.slice(9) })),
 			{
 				// TODO support Tailwind here?
+				runes: true
 			}
 		);
 	}

--- a/packages/repl/src/lib/Bundler.svelte.ts
+++ b/packages/repl/src/lib/Bundler.svelte.ts
@@ -1,4 +1,5 @@
 import type { BundleResult } from './public';
+import type { BundleOptions } from './workers/workers';
 import type { File } from './Workspace.svelte';
 
 let uid = 1;
@@ -46,7 +47,7 @@ export default class Bundler {
 		this.#worker.postMessage({ type: 'init', svelte_version });
 	}
 
-	bundle(files: File[], options: { tailwind?: boolean }) {
+	bundle(files: File[], options: BundleOptions) {
 		this.#worker.postMessage({
 			uid,
 			type: 'bundle',

--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -290,7 +290,8 @@ async function get_bundle(
 				const compilerOptions: any = {
 					filename: name + '.svelte',
 					generate: Number(svelte.VERSION.split('.')[0]) >= 5 ? 'client' : 'dom',
-					dev: true
+					dev: true,
+					runes: options.runes
 				};
 
 				if (can_use_experimental_async) {

--- a/packages/repl/src/lib/workers/workers.d.ts
+++ b/packages/repl/src/lib/workers/workers.d.ts
@@ -50,7 +50,8 @@ export interface MigrateOutput {
 }
 
 export interface BundleOptions {
-	tailwind: boolean;
+	tailwind?: boolean;
+	runes?: boolean;
 }
 
 export type BundleMessageData = {


### PR DESCRIPTION
alternative to #1272 — rather than cluttering files with `<svelte:options>`, I think it's reasonable to opt into runes mode for the duration of the tutorial. It does mean that the 'before' code in a case like https://svelte.dev/tutorial/svelte/universal-reactivity would behave differently if pasted into a project locally, but it serves the same pedagogical goal, and anticipates a future time in which everything is runes mode.