### PR TITLE
only create supabase client when env vars are present

### DIFF
--- a/apps/svelte.dev/src/lib/db/client.js
+++ b/apps/svelte.dev/src/lib/db/client.js
@@ -14,6 +14,8 @@ if (!building && (!env.SUPABASE_URL || !env.SUPABASE_KEY)) {
 // @ts-ignore-line
 export const client =
 	!building &&
+	env.SUPABASE_URL &&
+	env.SUPABASE_KEY &&
 	createClient(env.SUPABASE_URL, env.SUPABASE_KEY, {
 		global: { fetch },
 		auth: { persistSession: false }


### PR DESCRIPTION
follow-up to #1268 — we still need to check for the presence of these env vars, we just need to make sure we don't try and read dynamic env vars during prerendering or it blows up, hence the `!building` gate