### PR TITLE
fix: set default selection color

### DIFF
--- a/packages/repl/src/lib/Editor/codemirror.css
+++ b/packages/repl/src/lib/Editor/codemirror.css
@@ -119,6 +119,7 @@
 
 	.cm-selectionBackground {
 		border-radius: 2px;
+		background-color: var(--sk-bg-unfocused-selection);
 	}
 
 	.cm-selectionMatch {

--- a/packages/site-kit/src/lib/styles/tokens/colours.css
+++ b/packages/site-kit/src/lib/styles/tokens/colours.css
@@ -22,6 +22,7 @@
 	--sk-bg-4: hsl(0, 0%, 95%); /* hover states and highlights */
 	--sk-bg-accent: var(--sk-fg-accent);
 	--sk-bg-selection: hsla(204, 100%, 63%, 0.3);
+	--sk-bg-unfocused-selection: hsla(204, 50%, 63%, 0.2);
 	--sk-bg-highlight: hsl(60, 100%, 80%);
 
 	/* Border color — use this for all borders, except 'active' borders (e.g. current nav) which use `--sk-fg-accent`  */


### PR DESCRIPTION
Closes #658
This PR changes the default selection color `#d9d9d9`, which is used in the JS output and CSS output tabs and in the unfocused editor, to a similar to `--sk-bg-selection` one what looks nice on both light and dark themes.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
