### PR TITLE
fix: prevent lifecycle_double_unmount warning in REPL

### DIFF
--- a/packages/repl/src/lib/Output/Viewer.svelte
+++ b/packages/repl/src/lib/Output/Viewer.svelte
@@ -196,12 +196,16 @@
 								return untrack(() => original[method].apply(this, v));
 							}
 						}
-						const component = mount(App, { target: document.body });
-						window.__unmount_previous = () => {
-							for (const method of console_methods) {
-								console[method] = original[method];
+						let component;
+						try {
+							component = mount(App, { target: document.body });
+						} finally {
+							window.__unmount_previous = () => {
+								for (const method of console_methods) {
+									console[method] = original[method];
+								}
+								if (component) unmount(component);
 							}
-							unmount(component);
 						}
 					}
 					//# sourceURL=playground:output

--- a/packages/repl/src/lib/Output/Viewer.svelte
+++ b/packages/repl/src/lib/Output/Viewer.svelte
@@ -205,6 +205,7 @@
 									console[method] = original[method];
 								}
 								if (component) unmount(component);
+								window.__unmount_previous = null;
 							}
 						}
 					}


### PR DESCRIPTION
Unmount component only if it was successfully mounted to prevent annoying lifecycle_double_unmount warning. Plus always restore console methods.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
