### PR TITLE
use class-based reacgtivity for logs in playground

### DIFF
--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import Viewer from '@sveltejs/repl/viewer';
-	import Console, { type Log } from '@sveltejs/repl/console';
+	import { Console, type Log } from '@sveltejs/repl/console';
 	import { theme } from '@sveltejs/site-kit/state';
 	import Chrome from './Chrome.svelte';
 	import Loading from './Loading.svelte';

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -45,8 +45,8 @@
 			"svelte": "./src/lib/Workspace.svelte.ts"
 		},
 		"./console": {
-			"types": "./src/lib/Output/console/Console.svelte",
-			"svelte": "./src/lib/Output/console/Console.svelte"
+			"types": "./src/lib/Output/console/index.ts",
+			"svelte": "./src/lib/Output/console/index.ts"
 		}
 	},
 	"files": [

--- a/packages/repl/src/lib/Output/console/Console.svelte
+++ b/packages/repl/src/lib/Output/console/Console.svelte
@@ -1,23 +1,6 @@
-<script module lang="ts">
-	export type Log = {
-		command: 'info' | 'warn' | 'error' | 'table' | 'group' | 'clear' | 'unclonable';
-		action?: 'console';
-		args?: any[];
-		collapsed?: boolean;
-		expanded?: boolean;
-		count?: number;
-		logs?: Log[];
-		stack?: Array<{
-			label?: string;
-			location?: string;
-		}>;
-		data?: any;
-		columns?: string[];
-	};
-</script>
-
 <script lang="ts">
 	import ConsoleLine from './ConsoleLine.svelte';
+	import type { Log } from './Log.svelte';
 
 	export let logs: Log[];
 </script>

--- a/packages/repl/src/lib/Output/console/ConsoleLine.svelte
+++ b/packages/repl/src/lib/Output/console/ConsoleLine.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import JSONNode from '@sveltejs/svelte-json-tree';
 	import ConsoleTable from './ConsoleTable.svelte';
-	import type { Log } from './Console.svelte';
+	import type { Log } from './Log.svelte';
 
 	export let log: Log;
 	export let depth = 0;

--- a/packages/repl/src/lib/Output/console/Log.svelte.ts
+++ b/packages/repl/src/lib/Output/console/Log.svelte.ts
@@ -1,0 +1,22 @@
+type Command = 'info' | 'warn' | 'error' | 'table' | 'group' | 'clear' | 'unclonable';
+
+export class Log {
+	command: Command;
+	args?: any[];
+	stack?: Array<{
+		label?: string;
+		location?: string;
+	}>;
+	data?: any;
+	columns?: string[];
+
+	collapsed = $state(false);
+	expanded = $state(false);
+	count = $state(1);
+	logs = $state([]);
+
+	constructor(data: any) {
+		this.command = data.command;
+		Object.assign(this, data);
+	}
+}

--- a/packages/repl/src/lib/Output/console/index.ts
+++ b/packages/repl/src/lib/Output/console/index.ts
@@ -1,0 +1,2 @@
+export { default as Console } from './Console.svelte';
+export { Log } from './Log.svelte';


### PR DESCRIPTION
I ballsed up the migration of `Viewer.svelte` to runes mode, the result being that things are logged incorrectly:

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/107c4474-8920-4161-9b29-1f0911ab593d" />

This PR updates the logger to use classes, which are more idiomatic and more performant