### PR TITLE
feat: add reset button to REPL

### DIFF
--- a/packages/repl/src/lib/Output/Output.svelte
+++ b/packages/repl/src/lib/Output/Output.svelte
@@ -66,6 +66,8 @@
 
 	let current = $derived(workspace.current_compiled);
 
+	let resultTab: Viewer;
+
 	// TODO this effect is a bit of a code smell
 	$effect(() => {
 		if (current?.error) {
@@ -189,6 +191,15 @@
 			<button class="active">Markdown</button>
 		{:else}
 			<button aria-current={view === 'result'} onclick={() => (view = 'result')}>Result</button>
+			<button
+				aria-current={view === 'result'}
+				aria-label="Reset result"
+				class="reset-result"
+				onclick={() => {
+					view = 'result';
+					resultTab.reset();
+				}}
+			></button>
 			<button aria-current={view === 'js'} onclick={() => (view = 'js')}>JS output</button>
 			<button aria-current={view === 'css'} onclick={() => (view = 'css')}>CSS output</button>
 			<button aria-current={view === 'ast'} onclick={() => (view = 'ast')}>AST output</button>
@@ -199,6 +210,7 @@
 <!-- component viewer -->
 <div class="tab-content" class:visible={!is_markdown && view === 'result'}>
 	<Viewer
+		bind:this={resultTab}
 		bind:error={runtimeError}
 		{status}
 		{relaxed}
@@ -277,6 +289,18 @@
 
 		&[aria-current='true'] {
 			border-bottom: 1px solid var(--sk-fg-accent);
+		}
+
+		&.reset-result {
+			width: 2em;
+			vertical-align: bottom;
+			background: url(./reset-light.svg) 50% 50% no-repeat;
+			background-size: 1em;
+			margin-left: -1ch;
+			cursor: pointer;
+			:root.dark & {
+				background-image: url(./reset-dark.svg);
+			}
 		}
 	}
 

--- a/packages/repl/src/lib/Output/Viewer.svelte
+++ b/packages/repl/src/lib/Output/Viewer.svelte
@@ -231,6 +231,10 @@
 		}
 	});
 
+	export const reset = () => {
+		if (ready) apply_bundle(bundle);
+	};
+
 	$effect(() => {
 		if (injectedCSS && proxy && ready) {
 			proxy.eval(

--- a/packages/repl/src/lib/Output/reset-dark.svg
+++ b/packages/repl/src/lib/Output/reset-dark.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.364 18.364C16.7353 19.9927 14.4853 21 12 21C7.02945 21 3 16.9706 3 12C3 7.02945 7.02945 3 12 3C14.4853 3 16.7353 4.00736 18.364 5.63605C19.193 6.46505 21 8.5 21 8.5" stroke="#d4d4d4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 4V8.5H16.5" stroke="#d4d4d4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/repl/src/lib/Output/reset-light.svg
+++ b/packages/repl/src/lib/Output/reset-light.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.364 18.364C16.7353 19.9927 14.4853 21 12 21C7.02945 21 3 16.9706 3 12C3 7.02945 7.02945 3 12 3C14.4853 3 16.7353 4.00736 18.364 5.63605C19.193 6.46505 21 8.5 21 8.5" stroke="#262626" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 4V8.5H16.5" stroke="#262626" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Closes #1126
The button just re-mounts the App, but maybe re-instantiating the entire iframe, to clean up forgotten timers etc., would be better.
The button location isn't the best one - there is no address bar, like in the tutorial or SvelteLab, so alternatives are the console head and before the buttons Fork and Save the REPL. But I find them a bit too far from the tab.

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
