### PR TITLE
fix `$props()` and `$props.id()` autocompletion

### DIFF
--- a/packages/site-kit/src/lib/codemirror/autocompletionDataProvider.js
+++ b/packages/site-kit/src/lib/codemirror/autocompletionDataProvider.js
@@ -533,7 +533,7 @@ const is_statement = (node) => {
  * @type {import("./types").Test}
  */
 const is_props = (node, _, selected) => {
-	if (selected.type !== 'svelte') return false;
+	if (!selected.endsWith('.svelte')) return false;
 
 	return (
 		node.name === 'VariableName' &&
@@ -577,20 +577,9 @@ const is_bindable = (node, context) => {
  * @type {import("./types").Test}
  */
 const is_props_id_call = (node, context, selected) => {
-	if (!selected.match(/\.svelte$/)) return false;
-	if (!is_state_call(node, context, selected)) return false;
-	if (node.parent?.parent?.name !== 'Script') return false;
-	return true;
-};
-
-/**
- * @type {import("./types").Test}
- */
-const is_props_id = (node, context, selected) => {
-	if (!selected.match(/\.svelte$/)) return false;
-	if (!is_state(node, context, selected)) return false;
-	if (node.parent?.parent?.name !== 'Script') return false;
-	return true;
+	return (
+		is_state_call(node, context, selected) && node.parent?.parent?.parent?.parent?.name === 'Script'
+	);
 };
 
 export const runes = [
@@ -598,7 +587,7 @@ export const runes = [
 	{ snippet: '$state', test: is_state_call },
 	{ snippet: '$props()', test: is_props },
 	{ snippet: '$props.id', test: is_props_id_call },
-	{ snippet: '$props.id()', test: is_props_id },
+	{ snippet: '$props.id()', test: is_props },
 	{ snippet: '$derived(${});', test: is_state },
 	{ snippet: '$derived', test: is_state_call },
 	{ snippet: '$derived.by(() => {\n\t${}\n});', test: is_state },


### PR DESCRIPTION
follow-up to #1307, which doesn't quite work — it doesn't correctly recognise when you're adding `.id` to an existing `$props()` call. We also don't need a dedicated `is_props_id` function, because if `is_props` worked (which it doesn't currently, but does in this PR) then it's the same test.