### PR TITLE
fix: improve underlining in "On this page" 

### DIFF
--- a/apps/svelte.dev/src/routes/docs/[topic]/[...path]/OnThisPage.svelte
+++ b/apps/svelte.dev/src/routes/docs/[topic]/[...path]/OnThisPage.svelte
@@ -89,8 +89,7 @@
 		@media (max-width: 1199px) {
 			margin: 4rem 0;
 
-			/* TODO remove :global once https://github.com/sveltejs/svelte/issues/13779 is fixed */
-			:global(&:not(:has(li:nth-child(2)))) {
+			&:not(:has(li:nth-child(2))) {
 				/* hide widget if there are no subheadings */
 				display: none;
 			}
@@ -165,8 +164,7 @@
 					rotate: 90deg;
 				}
 
-				/* TODO remove :global once https://github.com/sveltejs/svelte/issues/13779 is fixed */
-				:global(& + nav) {
+				& + nav {
 					display: block;
 				}
 			}


### PR DESCRIPTION
This ensures that the anchor that is clicked is always the one that gets underlined, even if just scrolling to that heading would underline a different anchor.

A good test page for this https://svelte.dev/docs/kit/introduction; set the browser window size to 1200x1200 and try to click on "What is SvelteKit" in the right sidebar.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
