### PR TITLE
fix: resolve imports for `local` version

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -219,9 +219,12 @@ async function get_bundle(
 			}
 
 			// importing a file from the same package via pkg.imports
-			if (importee[0] === '#' && current) {
-				const subpath = resolve_subpath(current, importee);
-				return normalize_path(current, subpath.slice(2));
+			if (importee[0] === '#') {
+				if (current) {
+					const subpath = resolve_subpath(current, importee);
+					return normalize_path(current, subpath.slice(2));
+				}
+				return await resolve_local(importee);
 			}
 
 			// importing an external package -> `npm://$/<name>@<version>/<path>`

--- a/packages/repl/src/lib/workers/npm.ts
+++ b/packages/repl/src/lib/workers/npm.ts
@@ -219,9 +219,14 @@ let local_svelte_pkg: Promise<any>;
 export async function resolve_local(specifier: string) {
 	const pkg = await (local_svelte_pkg ??= fetch(LOCAL_PKG_URL).then((r) => r.json()));
 
-	const subpath = resolve.exports(pkg, specifier.replace('svelte', '.'), {
-		browser: true
-	})![0] as string;
+	const subpath =
+		specifier[0] === '#'
+			? (resolve.imports(pkg, specifier, {
+					browser: true
+				})![0] as string)
+			: (resolve.exports(pkg, specifier.replace('svelte', '.'), {
+					browser: true
+				})![0] as string);
 
 	return new URL(subpath, LOCAL_PKG_URL).href;
 }


### PR DESCRIPTION
Without this if you try to launch the playground with `version=local` it will fail to resolve the `pkg.imports` for the local version of svelte.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
