### PR TITLE
fix: Button says 'dice' but there is only one die

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/06-await-blocks/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/06-await-blocks/+assets/app-a/src/lib/App.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <button onclick={() => promise = roll()}>
-	roll the dice
+	roll the die
 </button>
 
 <p>...rolling</p>

--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/06-await-blocks/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/06-await-blocks/+assets/app-b/src/lib/App.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <button onclick={() => promise = roll()}>
-	roll the dice
+	roll the die
 </button>
 
 {#await promise}


### PR DESCRIPTION
The button says "roll the dice" (plural) but the code only implements 1 singular die.

I understand the need of having issues and discussions, but I hope that fixing a label doesn't need that.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
