### PR TITLE
fix: D6 die roll could produce 0

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/06-await-blocks/+assets/app-a/src/lib/utils.js
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/06-await-blocks/+assets/app-a/src/lib/utils.js
@@ -9,7 +9,7 @@ export async function roll() {
 				return;
 			}
 
-			fulfil(Math.ceil(Math.random() * 6));
+			fulfil(Math.floor(Math.random() * 6) + 1);
 		}, 1000);
 	});
 }


### PR DESCRIPTION
This is almost a non-issue, but the old implementation of a D6 die roll was able to produce zero, although with very low likelihood.

From [the Math.random documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random), my boldface:

> The `Math.random()` static method returns a floating-point, pseudo-random number that's greater than or **equal to 0** and less than 1

It might seem petty and like a waste of time, but I think there's also no reason to keep an error in a tutorial.

Again, there's no issue, but if you feel that it would be valuable I'd be happy to create one.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
