### PR TITLE
fix: Prevents lightbulb pseudo element from blocking interactivity with underlying contents

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -415,6 +415,7 @@
 					top: 0.05em;
 					background: var(--sk-fg-accent);
 					mask: url(icons/lightbulb) no-repeat 0.5rem 0 / 2.6rem;
+					pointer-events: none;
 				}
 			}
 


### PR DESCRIPTION
Addresses an issue where the lightbulb icon pseudo-element was inadvertently capturing pointer events. for underlying elements by being oversized.

- Sets `pointer-events: none` on the icon pseudo-element to prevent unintended interactions.

The size could probably be fixed as well, but this prevents any unintentional pointer events since this appears to be only artistic anyway.

<img src="https://github.com/user-attachments/assets/0dea966f-589d-4efa-b691-961dbd1517f5" alt="">


<small>Seen on https://svelte.dev/docs/svelte/use</small>