### PR TITLE
feat: Download Svelte App with Tailwind CSS and fix app.css bug along side

### DIFF
--- a/apps/svelte.dev/.env
+++ b/apps/svelte.dev/.env
@@ -1,8 +1,8 @@
-SUPABASE_URL=
-SUPABASE_KEY=
+SUPABASE_URL=https://fgffbwzjvuacbgumcsge.supabase.co
+SUPABASE_KEY=rBCAuM33T4pdrhm1Y3hzGnlxWPfLBb8lI3ZHa3yIuphBBx9DT9/zf7/AuYgP3M3Llst030ect/xZEKiTuer/0w==
 
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
+GITHUB_CLIENT_ID=Ov23ligzz3gnuw49XeqW
+GITHUB_CLIENT_SECRET=98d6876b2cd82f95b01141e6361ebeb8ac453275
 
 # disable prerendering with `PRERENDER=false pnpm build` — this is useful for speeding up builds when previewing locally
 PRERENDER=true

--- a/apps/svelte.dev/.gitignore
+++ b/apps/svelte.dev/.gitignore
@@ -8,6 +8,7 @@
 /src/routes/_home/Supporters/donors.js
 /scripts/svelte-template
 /static/svelte-template.json
+/static/svelte-tailwind-template.json
 
 # git-repositories of synced docs go here
 /repos/

--- a/apps/svelte.dev/content/docs/svelte/07-misc/07-v5-migration-guide.md
+++ b/apps/svelte.dev/content/docs/svelte/07-misc/07-v5-migration-guide.md
@@ -834,9 +834,9 @@ Svelte 5 is more strict about the HTML structure and will throw a compiler error
 
 Assignments to destructured parts of a `@const` declaration are no longer allowed. It was an oversight that this was ever allowed.
 
-### :is(...) and :where(...) are scoped
+### :is(...), :has(...), and :where(...) are scoped
 
-Previously, Svelte did not analyse selectors inside `:is(...)` and `:where(...)`, effectively treating them as global. Svelte 5 analyses them in the context of the current component. As such, some selectors may now be treated as unused if they were relying on this treatment. To fix this, use `:global(...)` inside the `:is(...)/:where(...)` selectors.
+Previously, Svelte did not analyse selectors inside `:is(...)`, `:has(...)`, and `:where(...)`, effectively treating them as global. Svelte 5 analyses them in the context of the current component. As such, some selectors may now be treated as unused if they were relying on this treatment. To fix this, use `:global(...)` inside the `:is(...)/:has(...)/:where(...)` selectors.
 
 When using Tailwind's `@apply` directive, add a `:global` selector to preserve rules that use Tailwind-generated `:is(...)` selectors:
 

--- a/apps/svelte.dev/scripts/update.js
+++ b/apps/svelte.dev/scripts/update.js
@@ -9,4 +9,5 @@ const env = {
 
 fork(`${dir}/get_contributors.js`, { env });
 fork(`${dir}/get_donors.js`, { env });
+fork(`${dir}/get_svelte_tailwind_template.js`, { env });
 fork(`${dir}/get_svelte_template.js`, { env });

--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
@@ -97,10 +97,12 @@
 	}
 
 	async function download() {
-		const { files: components, imports } = repl.toJSON();
+		const { files: components, imports, tailwind } = repl.toJSON();
 
 		const files: Array<{ path: string; data: string }> = await (
-			await fetch('/svelte-template.json')
+			tailwind
+				? await fetch('/svelte-tailwind-template.json')
+				: await fetch('/svelte-template.json')
 		).json();
 
 		if (imports.length > 0) {


### PR DESCRIPTION
PR for Issue #1227 Tailwind enabled download with app.css bug

**Feat: Download Svelte App with Tailwind CSS when enabled.**
**Bug: Fix along side with removing app.css unwanted codes.**

I created another javascript file to get svelte template but with tailwind css config.
And then based on `workspace.tailwind` it will be conditionally use different templates
