### PR TITLE
add #snippet and @render completions

### DIFF
--- a/packages/site-kit/src/lib/codemirror/index.js
+++ b/packages/site-kit/src/lib/codemirror/index.js
@@ -25,13 +25,18 @@ const logic_block_snippets = [
 		label: '#await :then',
 		type: 'keyword'
 	}),
-	snippetCompletion('#key ${}}\n\n{/key', { label: '#key', type: 'keyword' })
+	snippetCompletion('#key ${}}\n\n{/key', { label: '#key', type: 'keyword' }),
+	snippetCompletion('#snippet ${}()}\n\n{/snippet', {
+		label: '#snippet',
+		type: 'keyword'
+	})
 ];
 
 const special_tag_snippets = [
 	snippetCompletion('@html ${}', { label: '@html', type: 'keyword' }),
 	snippetCompletion('@debug ${}', { label: '@debug', type: 'keyword' }),
-	snippetCompletion('@const ${}', { label: '@const', type: 'keyword' })
+	snippetCompletion('@const ${}', { label: '@const', type: 'keyword' }),
+	snippetCompletion('@render ${}()', { label: '@render', type: 'keyword' })
 ];
 
 /**


### PR DESCRIPTION
The playground lacks #snippet and @render completions, this PR adds them

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
