### PR TITLE
chore: add v0 build setup

### DIFF
--- a/packages/repl/src/routes/+layout.server.ts
+++ b/packages/repl/src/routes/+layout.server.ts
@@ -1,1 +1,1 @@
-export const prerender = true;
+export const ssr = false;

--- a/packages/repl/src/routes/+page.svelte
+++ b/packages/repl/src/routes/+page.svelte
@@ -1,4 +1,10 @@
-<script lang="ts">
+<script>
+	import V0 from './v0.svelte';
+</script>
+
+<V0 />
+
+<!-- <script lang="ts">
 	import Repl from '$lib/Repl.svelte';
 	import { onMount } from 'svelte';
 	import '@sveltejs/site-kit/styles/index.css';
@@ -35,4 +41,4 @@
 	main {
 		height: 100vh;
 	}
-</style>
+</style> -->

--- a/packages/repl/src/routes/v0.svelte
+++ b/packages/repl/src/routes/v0.svelte
@@ -1,0 +1,28 @@
+<!-- This component should be the entry point when compiling the REPL as a SvelteKit app for the v0 preview window -->
+<script lang="ts">
+	import Repl from '$lib/Repl.svelte';
+	import { onMount } from 'svelte';
+	import '@sveltejs/site-kit/styles/index.css';
+
+	let repl: ReturnType<typeof Repl>;
+
+	onMount(() => {
+		// @ts-expect-error so that v0 can interact with the REPL (it does load this SvelteKit app inline in its Next.js app)
+		window.__svelte_repl = repl;
+	});
+</script>
+
+<main>
+	<Repl bind:this={repl} embedded="output-only" />
+</main>
+
+<style>
+	:global(body) {
+		margin: 0;
+		padding: 0;
+	}
+
+	main {
+		height: 100vh;
+	}
+</style>

--- a/packages/repl/svelte.config.js
+++ b/packages/repl/svelte.config.js
@@ -7,7 +7,10 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter(),
+		output: {
+			bundleStrategy: 'single'
+		}
 	}
 };
 

--- a/packages/repl/vite.config.ts
+++ b/packages/repl/vite.config.ts
@@ -2,5 +2,11 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	ssr: {
+		noExternal: ['@sveltejs/site-kit', '@sveltejs/repl']
+	},
+	worker: {
+		format: 'es'
+	}
 });


### PR DESCRIPTION
This is used to bundle a SvelteKit playground app that can then be embedded in v0

Since rarely anyone builds/runs the playground directly (only through the app) this should be fine to land (and you can always comment in the old thing to play around with stuff)