### PR TITLE
Only focus search when no shiftKey

### DIFF
--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -127,7 +127,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 
 <svelte:window
 	onkeydown={(e) => {
-		if (e.key === 'k' && (navigator.platform === 'MacIntel' ? e.metaKey : e.ctrlKey)) {
+		if (e.key === 'k' && !e.shiftKey && (navigator.platform === 'MacIntel' ? e.metaKey : e.ctrlKey)) {
 			e.preventDefault();
 			search.query = '';
 


### PR DESCRIPTION
When using Ctrl/Cmd+Shift+k in repl/tutorial you expect the current line to be removed, instead search in the nav-bar is focused. This change should fix that.
