### PR TITLE
fix: faster/more robust commonjs playground plugin

### DIFF
--- a/packages/repl/src/lib/workers/bundler/index.ts
+++ b/packages/repl/src/lib/workers/bundler/index.ts
@@ -76,6 +76,8 @@ self.addEventListener('message', async (event: MessageEvent<BundleMessageData>) 
 						can_use_experimental_async
 					);
 
+					console.log('[bundle worker result]', result);
+
 					if (JSON.stringify(result.error) === JSON.stringify(ABORT)) return;
 					if (result && uid === current_id) postMessage(result);
 				});


### PR DESCRIPTION
Handle some edge cases around default exports, a especially weird code snippet of a specific very popular but abandoned library, and bail in more cases for perf
 