### PR TITLE
docs: clarify class attribute usage in Svelte templates

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/07-classes-and-styles/01-classes/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/07-classes-and-styles/01-classes/index.md
@@ -26,4 +26,20 @@ We can make it nicer though. Adding or removing a class based on some condition 
 
 This means 'always add the `card` class, and add the `flipped` class whenever `flipped` is truthy'.
 
+> **Note:** When using multiple expressions inside a `class={}` attribute, make sure to combine them within a single array or object.
+> Avoid separating expressions with commas at the top level (for example: `class={['foo'], 'bar'}`), as this creates a JavaScript sequence expression, which can cause errors in Runes mode and result in unintended behavior.
+>
+> ✅ Correct:
+>
+> ```svelte
+> <div class={["foo", condition && "bar", "baz"]}></div>
+> ```
+>
+> ❌ Avoid:
+>
+> ```svelte
+> <div class={["foo"], "bar"}></div>
+> ```
+>
+
 For more examples of how to combine conditional classes, [consult the `class` documentation](/docs/svelte/class).


### PR DESCRIPTION
Clarified class attribute usage in Svelte templates.
Added a note explaining how to correctly combine multiple class expressions inside class={} to avoid sequence expression issues in Runes mode. Includes examples of valid and invalid patterns for clarity.

I am a kinda beginner-ish dev. It took me over an hour to really test and find out this problem. Adding this comment would help new devs save time. Thanks.