### PR TITLE
fix: copy the correct code block

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -34,9 +34,8 @@
 
 			const ts = !!parent.querySelector('.ts-toggle:checked');
 			const code = parent.querySelector(
-				`pre[data-language]:${ts ? 'last' : 'first'}-of-type code`
+				`pre[data-language="${ts ? 'ts' : 'js'}"] code`
 			) as HTMLElement;
-
 			navigator.clipboard.writeText(get_text(code));
 		}
 	}

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -33,7 +33,7 @@
 				.find((node) => (node as HTMLElement).classList.contains('code-block')) as HTMLElement;
 
 			const ts = !!parent.querySelector('.ts-toggle:checked');
-			const query = ts ? `pre[data-language="ts"] code` : "pre code"
+			const query = ts ? `pre[data-language="ts"] code` : 'pre code';
 			const code = parent.querySelector(query) as HTMLElement;
 			navigator.clipboard.writeText(get_text(code));
 		}

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -33,9 +33,8 @@
 				.find((node) => (node as HTMLElement).classList.contains('code-block')) as HTMLElement;
 
 			const ts = !!parent.querySelector('.ts-toggle:checked');
-			const code = parent.querySelector(
-				`pre[data-language="${ts ? 'ts' : 'js'}"] code`
-			) as HTMLElement;
+			const query = ts ? `pre[data-language="ts"] code` : "pre code"
+			const code = parent.querySelector(query) as HTMLElement;
 			navigator.clipboard.writeText(get_text(code));
 		}
 	}


### PR DESCRIPTION
fixes #1403

## Changes
`/packages/site-kit/src/lib/components/Text.svelte`

### Problem
This issue is due to selecting wrong targeted element.

### Solution
I changed query for selecting document.
```js
parent.querySelector(`pre[data-language="${ts ? 'ts' : 'js'}"] code`) as HTMLElement;
```

### Impact
The change improves the logic for selecting code blocks based on the language toggle by explicitly filtering for the `ts` or `js` language instead of relying on positional selectors.