### PR TITLE
docs: remove old info about assigning derived state

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/03-derived-state/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/03-derived-state/index.md
@@ -17,4 +17,4 @@ We can now use this in our markup:
 <p>{numbers.join(' + ')} = +++{total}+++</p>
 ```
 
-The expression inside the `$derived` declaration will be re-evaluated whenever its dependencies (in this case, just `numbers`) are updated. Unlike normal state, derived state is read-only.
+The expression inside the `$derived` declaration will be re-evaluated whenever its dependencies (in this case, just `numbers`) are updated.


### PR DESCRIPTION
As mentioned in [the docs](https://svelte.dev/docs/svelte/$derived#Overriding-derived-values):  "Prior to Svelte 5.25, deriveds were read-only."

Also the playground seems to use a version >= 5.25. Assigning to a derived value works fine.