### PR TITLE
fix: migrate `ConsoleLine` to svelte 5 to show the right count for duplicate logs

### DIFF
--- a/packages/repl/src/lib/Output/console/ConsoleLine.svelte
+++ b/packages/repl/src/lib/Output/console/ConsoleLine.svelte
@@ -9,7 +9,7 @@
 		depth?: number;
 	}
 
-	let { log = $bindable(), depth = 0 }: Props = $props();
+	let { log, depth = 0 }: Props = $props();
 
 	function toggle_group_collapse() {
 		log.collapsed = !log.collapsed;

--- a/packages/repl/src/lib/Output/console/ConsoleLine.svelte
+++ b/packages/repl/src/lib/Output/console/ConsoleLine.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+	import ConsoleLine from './ConsoleLine.svelte';
 	import JSONNode from '@sveltejs/svelte-json-tree';
 	import ConsoleTable from './ConsoleTable.svelte';
 	import type { Log } from './Log.svelte';
 
-	export let log: Log;
-	export let depth = 0;
+	interface Props {
+		log: Log;
+		depth?: number;
+	}
+
+	let { log = $bindable(), depth = 0 }: Props = $props();
 
 	function toggle_group_collapse() {
 		log.collapsed = !log.collapsed;
@@ -182,7 +187,7 @@
 
 {#if log.command === 'group' && !log.collapsed}
 	{#each log.logs ?? [] as childLog}
-		<svelte:self log={childLog} depth={depth + 1} />
+		<ConsoleLine log={childLog} depth={depth + 1} />
 	{/each}
 {/if}
 


### PR DESCRIPTION
This has been bugging me for a while...if you have duplicate logs the counter doesn't actually go up...the reason is that `ConsoleLine` is a svelte 4 component using `Log` which is a svelte 5 class.

Well at least it was before this PR 😄

### A note on documentation PRs

If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example).

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
