### PR TITLE
fix: typo in CSS for the tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/+assets/static/shared.css
+++ b/apps/svelte.dev/content/tutorial/+assets/static/shared.css
@@ -189,7 +189,7 @@ progress:first-child {
 	margin-top: 0;
 }
 
-progress:lsat-child {
+progress:last-child {
 	margin-bottom: 0;
 }
 

--- a/apps/svelte.dev/scripts/create-tutorial-zip/common/src/app.html
+++ b/apps/svelte.dev/scripts/create-tutorial-zip/common/src/app.html
@@ -198,7 +198,7 @@
 				margin-top: 0;
 			}
 
-			progress:lsat-child {
+			progress:last-child {
 				margin-bottom: 0;
 			}
 

--- a/apps/svelte.dev/static/tutorial/shared.css
+++ b/apps/svelte.dev/static/tutorial/shared.css
@@ -197,7 +197,7 @@ progress:first-child {
 	margin-top: 0;
 }
 
-progress:lsat-child {
+progress:last-child {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
Found a lightning CSS warning during build about the selector "lsat-child". Should probably be "last-child".

```
[vite:css][lightningcss] Unsupported pseudo class or element: lsat-child
```

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
