### PR TITLE
bump kit

### DIFF
--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -52,7 +52,7 @@
 		"@supabase/supabase-js": "^2.43.4",
 		"@sveltejs/adapter-vercel": "^5.7.2",
 		"@sveltejs/enhanced-img": "^0.4.3",
-		"@sveltejs/kit": "^2.22.5",
+		"@sveltejs/kit": "https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be",
 		"@sveltejs/site-kit": "workspace:*",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
 		"@types/cookie": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.0.0(svelte@5.35.5)
       '@sveltejs/amp':
         specifier: ^1.1.4
-        version: 1.1.4(@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))
+        version: 1.1.4(@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))
       '@sveltejs/repl':
         specifier: workspace:*
         version: link:../../packages/repl
@@ -52,7 +52,7 @@ importers:
         version: 1.3.2
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)
+        version: 1.1.0(@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)
       '@webcontainer/api':
         specifier: ^1.1.5
         version: 1.1.9
@@ -113,13 +113,13 @@ importers:
         version: 2.43.4
       '@sveltejs/adapter-vercel':
         specifier: ^5.7.2
-        version: 5.7.2(@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(rollup@4.44.2)
+        version: 5.7.2(@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(rollup@4.44.2)
       '@sveltejs/enhanced-img':
         specifier: ^0.4.3
         version: 0.4.3(rollup@4.44.2)(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
       '@sveltejs/kit':
-        specifier: ^2.22.5
-        version: 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
+        specifier: https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be
+        version: https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
       '@sveltejs/site-kit':
         specifier: workspace:*
         version: link:../../packages/site-kit
@@ -1408,6 +1408,9 @@ packages:
     engines: {node: '>= 8.0.0'}
     hasBin: true
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@supabase/auth-js@2.64.2':
     resolution: {integrity: sha512-s+lkHEdGiczDrzXJ1YWt2y3bxRi+qIUnXcgkpLSrId7yjBeaXBFygNjTaoZLG02KNcYwbuZ9qkEIqmj2hF7svw==}
 
@@ -1442,11 +1445,13 @@ packages:
 
   '@sveltejs/adapter-vercel@5.7.2':
     resolution: {integrity: sha512-YuFi8qgetcmvlXLqMPDKrloH/bLq31DYHSQHS2oLujES+PomJIeE7/JxYhxFStauL9QDqQ8PwOFwcZrdU/vVtg==}
+    version: 5.7.2
     peerDependencies:
       '@sveltejs/kit': ^2.4.0
 
   '@sveltejs/amp@1.1.4':
     resolution: {integrity: sha512-krWC1QXzTUGj+QpAbkACJmOeRx2f3AHGwNip9eY7px1FFb0rHi5zdjAd2IJKYwLgX3xh462nr0kOtrZUv2EX6Q==}
+    version: 1.1.4
     peerDependencies:
       '@sveltejs/kit': ^1.0.0 || ^2.0.0
 
@@ -1458,6 +1463,16 @@ packages:
 
   '@sveltejs/kit@2.22.5':
     resolution: {integrity: sha512-l5i+LcDaoymD2mg5ziptnHmzzF79+c9twJiDoLWAPKq7afMEe4mvGesJ+LVtm33A92mLzd2KUHgtGSqTrvfkvg==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0
+
+  '@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be':
+    resolution: {tarball: https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be}
+    version: 2.26.1
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -1590,6 +1605,7 @@ packages:
 
   '@vercel/speed-insights@1.1.0':
     resolution: {integrity: sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg==}
+    version: 1.1.0
     peerDependencies:
       '@sveltejs/kit': ^1 || ^2
       next: '>= 13'
@@ -4190,6 +4206,8 @@ snapshots:
       fflate: 0.7.4
       string.prototype.codepointat: 0.2.1
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@supabase/auth-js@2.64.2':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -4241,9 +4259,9 @@ snapshots:
       '@sveltejs/kit': 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-vercel@5.7.2(@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(rollup@4.44.2)':
+  '@sveltejs/adapter-vercel@5.7.2(@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(rollup@4.44.2)':
     dependencies:
-      '@sveltejs/kit': 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
+      '@sveltejs/kit': https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
       '@vercel/nft': 0.29.2(rollup@4.44.2)
       esbuild: 0.25.6
     transitivePeerDependencies:
@@ -4251,9 +4269,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/amp@1.1.4(@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))':
+  '@sveltejs/amp@1.1.4(@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))':
     dependencies:
-      '@sveltejs/kit': 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
+      '@sveltejs/kit': https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
 
   '@sveltejs/enhanced-img@0.4.3(rollup@4.44.2)(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))':
     dependencies:
@@ -4269,6 +4287,25 @@ snapshots:
 
   '@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))':
     dependencies:
+      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
+      '@sveltejs/vite-plugin-svelte': 6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.14.1
+      cookie: 0.6.0
+      devalue: 5.1.1
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.17
+      mrmime: 2.0.0
+      sade: 1.8.1
+      set-cookie-parser: 2.7.1
+      sirv: 3.0.0
+      svelte: 5.35.5
+      vite: 7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)
+
+  '@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
       '@sveltejs/vite-plugin-svelte': 6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
       '@types/cookie': 0.6.0
@@ -4421,9 +4458,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/speed-insights@1.1.0(@sveltejs/kit@2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)':
+  '@vercel/speed-insights@1.1.0(@sveltejs/kit@https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)':
     optionalDependencies:
-      '@sveltejs/kit': 2.22.5(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
+      '@sveltejs/kit': https://pkg.pr.new/sveltejs/kit/@sveltejs/kit@e19e9be(@sveltejs/vite-plugin-svelte@6.0.0(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0)))(svelte@5.35.5)(vite@7.0.4(@types/node@20.19.6)(lightningcss@1.25.1)(tsx@4.19.0))
       svelte: 5.35.5
 
   '@vitest/expect@3.2.4':


### PR DESCRIPTION
This is temporarily necessary so that we can preview docs for https://github.com/sveltejs/kit/pull/13986. Once it's released we can get back on a stable version (and maybe even use the new features, though it won't truly make sense until we have async SSR)