### PR TITLE
fix: avoid including the default OG image for docs

### DIFF
--- a/apps/svelte.dev/src/routes/+layout.svelte
+++ b/apps/svelte.dev/src/routes/+layout.svelte
@@ -39,7 +39,7 @@
 </script>
 
 <svelte:head>
-	{#if !page.route.id || !page.route.id.startsWith('/blog/') || !/^\/docs\/[^\/]+\/[^\/]+$/.test(page.route.id)}
+	{#if !page.route.id || !(page.route.id.startsWith('/blog/') || /^\/docs\/[^\/]+\/[^\/]+$/.test(page.route.id))}
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:image" content="https://svelte.dev/images/twitter-thumbnail.jpg" />
 		<meta name="og:image" content="https://svelte.dev/images/twitter-thumbnail.jpg" />


### PR DESCRIPTION
Fixes the boolean logic for when to include the default OG images. Follow up to https://github.com/sveltejs/svelte.dev/pull/1443

Avoids it looking like this:
<img width="680" height="679" alt="two og images" src="https://github.com/user-attachments/assets/0f463a42-d856-4dd5-b0f6-1587a57e22a4" />

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
