### PR TITLE
refactor: improve tutorial algorithm from O(n) to O(1)

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/03-derived-state/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/03-derived-state/+assets/app-b/src/lib/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	let numbers = $state([1, 2, 3, 4]);
-	let total = $derived(numbers.reduce((t, n) => t + n, 0));
+	let total = $derived(numbers.length * (numbers.length + 1) / 2);
 
 	function addNumber() {
 		numbers.push(numbers.length + 1);

--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/03-derived-state/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/03-derived-state/index.md
@@ -7,7 +7,7 @@ Often, you will need to _derive_ state from other state. For this, we have the `
 ```js
 /// file: App.svelte
 let numbers = $state([1, 2, 3, 4]);
-+++let total = $derived(numbers.reduce((t, n) => t + n, 0));+++
++++let total = $derived(numbers.length * (numbers.length + 1) / 2);+++
 ```
 
 We can now use this in our markup:

--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/04-inspecting-state/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/04-inspecting-state/+assets/app-a/src/lib/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	let numbers = $state([1, 2, 3, 4]);
-	let total = $derived(numbers.reduce((t, n) => t + n, 0));
+	let total = $derived(numbers.length * (numbers.length + 1) / 2);
 
 	function addNumber() {
 		numbers.push(numbers.length + 1);

--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/04-inspecting-state/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/04-inspecting-state/+assets/app-b/src/lib/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	let numbers = $state([1, 2, 3, 4]);
-	let total = $derived(numbers.reduce((t, n) => t + n, 0));
+	let total = $derived(numbers.length * (numbers.length + 1) / 2);
 
 	function addNumber() {
 		numbers.push(numbers.length + 1);


### PR DESCRIPTION
Currently the derived state tutorial uses an O(n) algorithm to calculate the total number, while not a major issue as it is just a tutorial including a better algorithm could introduce beginner programmers to a more efficient way of calculating the sum.