### PR TITLE
fix: change mobile nav to link to svelte.dev bsky

### DIFF
--- a/packages/site-kit/src/lib/nav/MobileMenu.svelte
+++ b/packages/site-kit/src/lib/nav/MobileMenu.svelte
@@ -146,7 +146,7 @@
 
 						<ul>
 							<li><a href="/chat">Discord</a></li>
-							<li><a href="https://bsky.app/profile/sveltesociety.dev">Bluesky</a></li>
+							<li><a href="https://bsky.app/profile/svelte.dev">Bluesky</a></li>
 							<li><a href="https://github.com/sveltejs/svelte">GitHub</a></li>
 						</ul>
 					</div>

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -129,7 +129,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 					<span data-icon="discord"></span>
 				</a>
 
-				<a href="https://bsky.app/profile/sveltesociety.dev" aria-label="Svelte Society on Bluesky">
+				<a href="https://bsky.app/profile/svelte.dev" aria-label="Svelte on Bluesky">
 					<span data-icon="bluesky"></span>
 				</a>
 


### PR DESCRIPTION
Follow-up to #1470

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
