### PR TITLE
fix: make repl console scrollable

### DIFF
--- a/packages/repl/src/lib/Output/console/Console.svelte
+++ b/packages/repl/src/lib/Output/console/Console.svelte
@@ -13,6 +13,7 @@
 
 <style>
 	.container {
+		overflow: scroll;
 		--error-fg: #da106e;
 		--error-bg: #fff0f0;
 		--error-border: rgb(242, 214, 219);


### PR DESCRIPTION
For some reason the console in the REPL has had `overflow: hidden`, meaning that if there are too many logs to fit in the current view, you'd have to resize the console instead of just scrolling. This should fix that. 

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
