### PR TITLE
fix highlighting

### DIFF
--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -719,10 +719,17 @@ function replace_blank_lines(html: string) {
 }
 
 const delimiter_substitutes = {
-	'---': '             ',
-	'+++': '           ',
-	':::': '         '
+	'---': '                                           ',
+	'+++': '                                         ',
+	':::': '                                       '
 };
+
+const delimiter_patterns = Object.fromEntries(
+	Object.entries(delimiter_substitutes).map(([key, substitute]) => [
+		key,
+		new RegExp(`${substitute}([^ ][^]+?)${substitute}`, 'g')
+	])
+);
 
 function highlight_spans(content: string, classname: string) {
 	return content
@@ -878,13 +885,13 @@ async function syntax_highlight({
 		.replace(' tabindex="0"', '');
 
 	html = html
-		.replace(/ {13}([^ ][^]+?) {13}/g, (_, content) => {
+		.replace(delimiter_patterns['---'], (_, content) => {
 			return highlight_spans(content, 'highlight remove');
 		})
-		.replace(/ {11}([^ ][^]+?) {11}/g, (_, content) => {
+		.replace(delimiter_patterns['+++'], (_, content) => {
 			return highlight_spans(content, 'highlight add');
 		})
-		.replace(/ {9}([^ ][^]+?) {9}/g, (_, content) => {
+		.replace(delimiter_patterns[':::'], (_, content) => {
 			return highlight_spans(content, 'highlight');
 		});
 


### PR DESCRIPTION
fixes a small thing I noticed on https://svelte.dev/docs/kit/page-options#entries — this...

<img width="798" height="303" alt="image" src="https://github.com/user-attachments/assets/8e146454-2d54-49f7-bd9b-ada9bb14bf21" />

...should look like this:

<img width="789" height="294" alt="image" src="https://github.com/user-attachments/assets/35001838-f2df-4723-ad6f-3885a0afadf2" />
