### PR TITLE
feat: add vite-plugin-svelte docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ If you're creating a documentation PR, make sure you're targeting the right repo
 - `docs/svelte` -> https://github.com/sveltejs/svelte
 - `docs/kit` -> https://github.com/sveltejs/kit
 - `docs/cli` -> https://github.com/sveltejs/cli
+- `docs/vite-plugin-svelte` -> https://github.com/sveltejs/vite-plugin-svelte
 
 The tutorial, blog and examples are maintained within this repository.
 
@@ -17,6 +18,6 @@ The tutorial, blog and examples are maintained within this repository.
 ```
 pnpm install
 cd apps/svelte.dev
-USE_GIT=true pnpm sync-docs
+pnpm sync-docs -p
 pnpm run dev
 ```

--- a/apps/svelte.dev/scripts/sync-docs/index.ts
+++ b/apps/svelte.dev/scripts/sync-docs/index.ts
@@ -149,6 +149,14 @@ const packages: Package[] = [
 		pkg: 'packages/cli',
 		docs: 'documentation/docs',
 		types: null
+	},
+	{
+		name: 'vite-plugin-svelte',
+		repo: `${parsed.values.owner}/vite-plugin-svelte`,
+		branch: branches['vite-plugin-svelte'] ?? 'docs/omni-site-reformat',
+		pkg: 'packages/vite-plugin-svelte',
+		docs: 'documentation/docs',
+		types: null
 	}
 ];
 

--- a/apps/svelte.dev/src/routes/+layout.server.ts
+++ b/apps/svelte.dev/src/routes/+layout.server.ts
@@ -9,7 +9,7 @@ const nav_links: NavigationLink[] = [
 	{
 		title: 'Docs',
 		slug: 'docs',
-		sections: [docs.topics['docs/svelte'], docs.topics['docs/kit'], docs.topics['docs/cli']].map(
+		sections: [docs.topics['docs/svelte'], docs.topics['docs/kit'], docs.topics['docs/cli'], docs.topics['docs/vite-plugin-svelte']].map(
 			(topic) => ({
 				title: topic.metadata.title,
 				path: '/' + topic.slug, // this will make the UI show a flyout menu for the docs nav entry


### PR DESCRIPTION
Work in progress:

build fails in marked because vite-plugin-svelte docs don't import types in their code snippets currently.

todos:

- [ ] make it build 
- [ ] merge updated docs in vite-plugin-svelte
- [ ] switch from `docs/omni-site-reformat` branch to `main` in vite-plugin-svelte sync-docs config
