### PR TITLE
docs: fix wrong package name @opentelemetry/exporter-trace-oltp-proto

### DIFF
--- a/apps/svelte.dev/content/docs/kit/30-advanced/68-observability.md
+++ b/apps/svelte.dev/content/docs/kit/30-advanced/68-observability.md
@@ -70,7 +70,7 @@ To view your first trace, you'll need to set up a local collector. We'll use [Ja
 - Turn on the experimental flags mentioned earlier in your `svelte.config.js` file
 - Use your package manager to install the dependencies you'll need:
   ```sh
-  npm i @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-oltp-proto import-in-the-middle
+  npm i @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-proto import-in-the-middle
   ```
 - Create `src/instrumentation.server.js` with the following:
 


### PR DESCRIPTION
Fix package name in doc.

Wrong: @opentelemetry/exporter-trace-oltp-proto
Correct: @opentelemetry/exporter-trace-otlp-proto 

repository: https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto 

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
