### PR TITLE
Revert "Sync `kit` docs"

### DIFF
--- a/apps/svelte.dev/content/docs/kit/20-core-concepts/60-remote-functions.md
+++ b/apps/svelte.dev/content/docs/kit/20-core-concepts/60-remote-functions.md
@@ -161,9 +161,9 @@ export const getPost = query(v.string(), async (slug) => {
 
 Both the argument and the return value are serialized with [devalue](https://github.com/sveltejs/devalue), which handles types like `Date` and `Map` (and custom types defined in your [transport hook](hooks#Universal-hooks-transport)) in addition to JSON.
 
-### Updating queries
+### Refreshing queries
 
-Any query can be re-fetched via its `refresh` method, which retrieves the latest value from the server:
+Any query can be updated via its `refresh` method:
 
 ```svelte
 <button onclick={() => getPosts().refresh()}>
@@ -171,30 +171,7 @@ Any query can be re-fetched via its `refresh` method, which retrieves the latest
 </button>
 ```
 
-Alternatively, if you need to update its value manually, you can use the `set` method:
-
-```svelte
-<script>
-	import { getPosts } from './data.remote';
-	import { onMount } from 'svelte';
-
-	onMount(() => {
-		const ws = new WebSocket('/ws');
-		ws.addEventListener('message', (ev) => {
-			const message = JSON.parse(ev.data);
-			if (message.type === 'new-post') {
-				getPosts().set([
-					message.post,
-					...getPosts().current,
-				]);
-			}
-		});
-		return () => ws.close();
-	});
-</script>
-```
-
-> [!NOTE] Queries are cached while they're on the page, meaning `getPosts() === getPosts()`. This means you don't need a reference like `const posts = getPosts()` in order to update the query.
+> [!NOTE] Queries are cached while they're on the page, meaning `getPosts() === getPosts()`. This means you don't need a reference like `const posts = getPosts()` in order to refresh the query.
 
 ## form
 

--- a/apps/svelte.dev/content/docs/kit/98-reference/10-@sveltejs-kit.md
+++ b/apps/svelte.dev/content/docs/kit/98-reference/10-@sveltejs-kit.md
@@ -2192,12 +2192,6 @@ type RemotePrerenderFunction<Input, Output> = (
 ```dts
 type RemoteQuery<T> = RemoteResource<T> & {
 	/**
-	 * On the client, this function will update the value of the query without re-fetching it.
-	 *
-	 * On the server, this throws an error.
-	 */
-	set(value: T): void;
-	/**
 	 * On the client, this function will re-fetch the query from the server.
 	 *
 	 * On the server, this can be called in the context of a `command` or `form` and the refreshed data will accompany the action response back to the client.


### PR DESCRIPTION
We shouldn't have published these docs — see https://github.com/sveltejs/kit/pull/14304#discussion_r2299299623. For now I'm just going to revert, will review https://github.com/sveltejs/kit/pull/14304 (which updates them) later