### PR TITLE
fix: remove trailing `=` signs from hash urls

### DIFF
--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/gzip.js
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/gzip.js
@@ -6,7 +6,7 @@ export async function compress_and_encode_text(input) {
 		const { done, value } = await reader.read();
 		if (done) {
 			reader.releaseLock();
-			return btoa(buffer).replaceAll('+', '-').replaceAll('/', '_');
+			return btoa(buffer).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
 		} else {
 			for (let i = 0; i < value.length; i++) {
 				// decoding as utf-8 will make btoa reject the string

--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/gzip.js
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/gzip.js
@@ -6,6 +6,7 @@ export async function compress_and_encode_text(input) {
 		const { done, value } = await reader.read();
 		if (done) {
 			reader.releaseLock();
+			// Some sites like discord don't like it when links end with =
 			return btoa(buffer).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
 		} else {
 			for (let i = 0; i < value.length; i++) {


### PR DESCRIPTION
For some reason, certain sites (Discord) don't like it when you send links ending in `=`, and `=`s are only for optional padding in base64, so this should fix that.

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
