### PR TITLE
docs: use the set method instead of directly assigning a value to current

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/03-motion/01-tweens/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/03-motion/01-tweens/index.md
@@ -35,7 +35,7 @@ The `Tween` class has a writable `target` property and a readonly `current` prop
 ...and each of the event handlers:
 
 ```svelte
-<button onclick={() => (progress.+++target+++ = 0)}>
+<button onclick={() => (progress.+++set(0)+++)}>
 	0%
 </button>
 ```


### PR DESCRIPTION
In the current tutorial, directly assigning a value to `progress.current` for updates is not a supported method. According to the documentation, the `progress.set` method should be used instead.

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
