### PR TITLE
fix: scrollbar background on search results

### DIFF
--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -408,6 +408,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 	.results {
 		overflow: auto;
 		overscroll-behavior-y: none;
+		scrollbar-color: var(--sk-scrollbar) var(--sk-bg-2);
 	}
 
 	.results-container {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

Currently, the background of scrollbar in the search results modal is transparent.
It should have the same background color as the modal.

<details>
  <summary>Before</summary>
  <img width="129" height="658" alt="svelte-dev-search-results-scrollbar-before" src="https://github.com/user-attachments/assets/bfd5246e-3b0f-44fa-b23d-1d5058d13909" />
</details>

<details>
  <summary>After</summary>
  <img width="129" height="658" alt="svelte-dev-search-results-scrollbar-after" src="https://github.com/user-attachments/assets/27214558-2d8a-4f06-aaea-5d424b4dd3a0" />
</details>
