### PR TITLE
fix: change github icon to link to gh organization

### DIFF
--- a/packages/site-kit/src/lib/nav/MobileMenu.svelte
+++ b/packages/site-kit/src/lib/nav/MobileMenu.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation';
-	import { page } from '$app/state';
 	import { trap } from '../actions';
 	import { reduced_motion } from '../stores';
 	import { tick } from 'svelte';
@@ -10,7 +9,6 @@
 	import MobileSubMenu from './MobileSubMenu.svelte';
 	import type { NavigationLink } from '../types';
 	import ModalOverlay from '../components/ModalOverlay.svelte';
-	import { github_link } from './Nav.svelte';
 
 	interface Props {
 		links: NavigationLink[];
@@ -150,7 +148,7 @@
 							<li><a href="/chat">Discord</a></li>
 							<li><a href="https://bsky.app/profile/svelte.dev">Bluesky</a></li>
 							<li>
-								<a href={github_link(page)}>GitHub</a>
+								<a href="https://github.com/sveltejs">GitHub</a>
 							</li>
 						</ul>
 					</div>

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -2,19 +2,6 @@
 Top navigation bar for the application. It provides a slot for the left side, the right side, and the center.
 -->
 
-<script lang="ts" module>
-	import type { Page } from '@sveltejs/kit';
-	export function github_link(page: Page) {
-		if (page.url.pathname.startsWith('/tutorial')) {
-			return `https://github.com/sveltejs/${page.params.slug!.split('/')[0]}`;
-		}
-		if (page.url.pathname.startsWith('/docs')) {
-			return `https://github.com/sveltejs/${page.params.topic!}`;
-		}
-		return 'https://github.com/sveltejs/svelte';
-	}
-</script>
-
 <script lang="ts">
 	import { overlay_open, on_this_page_open } from '../stores';
 	import { search } from '../state/search.svelte';
@@ -146,7 +133,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 					<span data-icon="bluesky"></span>
 				</a>
 
-				<a href={github_link(page)} aria-label="GitHub Repo">
+				<a href="https://github.com/sveltejs" aria-label="GitHub Organization">
 					<span data-icon="github"></span>
 				</a>
 			</div>


### PR DESCRIPTION
This changes the GitHub icon in the navbar to link to the Svelte GitHub organization.

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
