### PR TITLE
fix(llms): preserve newlines in generated `llms-medium.txt` file

### DIFF
--- a/apps/svelte.dev/src/lib/server/llms.ts
+++ b/apps/svelte.dev/src/lib/server/llms.ts
@@ -106,7 +106,7 @@ function minimize_content(content: string, options?: Partial<MinimizeOptions>): 
 	}
 
 	if (settings.normalize_whitespace) {
-		minimized = minimized.replace(/\s+/g, ' ');
+		minimized = minimized.replace(/[^\S\n\t]+/g, ' ');
 	}
 
 	minimized = minimized.trim();

--- a/apps/svelte.dev/src/lib/server/llms.ts
+++ b/apps/svelte.dev/src/lib/server/llms.ts
@@ -14,7 +14,6 @@ interface MinimizeOptions {
 	remove_details_blocks: boolean;
 	remove_playground_links: boolean;
 	remove_prettier_ignore: boolean;
-	normalize_whitespace: boolean;
 }
 
 interface Topic {
@@ -27,8 +26,7 @@ const defaults: MinimizeOptions = {
 	remove_note_blocks: false,
 	remove_details_blocks: false,
 	remove_playground_links: false,
-	remove_prettier_ignore: false,
-	normalize_whitespace: false
+	remove_prettier_ignore: false
 };
 
 export function generate_llm_content(options: GenerateLlmContentOptions): string {
@@ -103,10 +101,6 @@ function minimize_content(content: string, options?: Partial<MinimizeOptions>): 
 			.split('\n')
 			.filter((line) => line.trim() !== '<!-- prettier-ignore -->')
 			.join('\n');
-	}
-
-	if (settings.normalize_whitespace) {
-		minimized = minimized.replace(/[^\S\n\t]+/g, ' ');
 	}
 
 	minimized = minimized.trim();

--- a/apps/svelte.dev/src/routes/llms-medium.txt/+server.ts
+++ b/apps/svelte.dev/src/routes/llms-medium.txt/+server.ts
@@ -29,8 +29,7 @@ export function GET() {
 			remove_note_blocks: true,
 			remove_details_blocks: true,
 			remove_playground_links: true,
-			remove_prettier_ignore: true,
-			normalize_whitespace: true
+			remove_prettier_ignore: true
 		}
 	});
 	const content = `<SYSTEM>This is the abridged developer documentation for Svelte and SvelteKit.</SYSTEM>\n\n${main_content}`;


### PR DESCRIPTION
<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->
Fixes #1463 

This PR fixes broken formatting in `llms-medium.txt` file by updating the regex in `llms.ts` file to preserve newlines and tabs for indentation.


### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
