### PR TITLE
feat: add new cmd in the Playground `sv create --from-playground`

### DIFF
--- a/packages/repl/src/lib/Input/ComponentSelector.svelte
+++ b/packages/repl/src/lib/Input/ComponentSelector.svelte
@@ -192,15 +192,15 @@
 
 			<button
 				class="copy-button"
-				title="Copy to clipboard"
-				aria-label="Copy to clipboard"
+				title="Copy `npx sv create --from-playground=&quot;...&quot;` to clipboard"
+				aria-label="Copy `npx sv create --from-playground=&quot;...&quot;` to clipboard"
 				onclick={() => {
 					navigator.clipboard.writeText(
 						`npx sv create --from-playground="${window.location.href}"`
 					);
 				}}
 			>
-				Copy <code>sv create --from-playground</code>
+				Set up locally
 			</button>
 		</Toolbox>
 	</div>
@@ -376,8 +376,6 @@
 
 	.copy-button {
 		position: relative;
-		height: 3.6rem;
-		margin-right: 2rem;
 
 		&::before,
 		&::after {
@@ -386,10 +384,10 @@
 			position: absolute;
 			width: 100%;
 			height: 100%;
-			right: 1.1rem;
-			top: 1.1rem;
+			right: 0;
+			top: 0;
 			background: currentColor;
-			mask: no-repeat 100% 0% / 1.6rem 1.6rem;
+			mask: no-repeat calc(100% - 1rem) 50% / 1.6rem 1.6rem;
 			transition: opacity 0.2s;
 			transition-delay: 0.6s;
 		}


### PR DESCRIPTION
Since `sv@0.9.5`, we can create a project from the playground ([check the doc](https://svelte.dev/docs/cli/sv-create#Options-from-playground-url))

To help the discoverability of this feature, we can add the command in the playground like this:

<img width="796" height="388" alt="image" src="https://github.com/user-attachments/assets/dba5ab0b-a74b-43d8-abac-cc10a9b25c12" />

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
