### PR TITLE
chore(tutorial/select-bindings): remove unnecessary `$state` rune

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/06-bindings/04-select-bindings/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/06-bindings/04-select-bindings/+assets/app-a/src/lib/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	let questions = $state([
+	let questions = [
 		{
 			id: 1,
 			text: `Where did you go to school?`
@@ -12,7 +12,7 @@
 			id: 3,
 			text: `What is another personal fact that an attacker could easily find with Google?`
 		}
-	]);
+	];
 
 	let selected = $state();
 

--- a/apps/svelte.dev/content/tutorial/01-svelte/06-bindings/04-select-bindings/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/06-bindings/04-select-bindings/+assets/app-b/src/lib/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	let questions = $state([
+	let questions = [
 		{
 			id: 1,
 			text: `Where did you go to school?`
@@ -12,7 +12,7 @@
 			id: 3,
 			text: `What is another personal fact that an attacker could easily find with Google?`
 		}
-	]);
+	];
 
 	let selected = $state();
 


### PR DESCRIPTION
<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

Closes #1527 

This PR removes unnecessary `$state` rune from the static questions array in select-bindings tutorial.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
