### PR TITLE
fix: underlines the wrong section title

### DIFF
--- a/apps/svelte.dev/src/routes/docs/[topic]/[...path]/OnThisPage.svelte
+++ b/apps/svelte.dev/src/routes/docs/[topic]/[...path]/OnThisPage.svelte
@@ -10,12 +10,19 @@
 	afterNavigate(() => {
 		current = location.hash.slice(1);
 		headings = content.querySelectorAll('h2');
-		update(); // Ensure active link is set correctly on navigation
+		setTimeout(() => update(), 0); // Delay to allow layout to settle
 	});
 
 	// Update function to activate the correct section link
 	function update() {
 		const threshold = (innerHeight * 1) / 3;
+
+		// If scrolled less than threshold, activate the page title
+		if (scrollY < threshold) {
+			current = '';
+			return;
+		}
+
 		let found = false;
 
 		for (let i = 0; i < headings.length; i++) {
@@ -33,10 +40,7 @@
 			}
 		}
 
-		// Handle case when scrolled to the top of the page
-		if (!found && scrollY === 0) {
-			current = '';
-		}
+		// If no heading found, keep current as is
 	}
 </script>
 


### PR DESCRIPTION
issue #1542 

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

### Description

Now, the underline is selected as per the section and the Cookies title is visible on the Brave browser discussed [here](https://github.com/sveltejs/svelte.dev/issues/1542#issuecomment-3326725353)

<img width="1919" height="995" alt="image" src="https://github.com/user-attachments/assets/11024481-dcf9-418c-b4d5-abf761c439b0" />

<img width="1919" height="1001" alt="image" src="https://github.com/user-attachments/assets/29d50ae0-5034-4df0-ac18-7c61a0bd3dd8" />
