### PR TITLE
Revise component naming convention note

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/01-introduction/05-nested-components/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/01-introduction/05-nested-components/index.md
@@ -23,4 +23,4 @@ Add a `<script>` tag to the top of `App.svelte` that imports `Nested.svelte`...
 
 Notice that even though `Nested.svelte` has a `<p>` element, the styles from `App.svelte` don't leak in.
 
-> [!NOTE] Component names are capitalised, to distinguish them from HTML elements.
+> [!NOTE] Component names are, at minimum, sentence-cased, to distinguish them from HTML elements.


### PR DESCRIPTION
Updated note on component naming conventions.

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
