### PR TITLE
docs: clarify async SSR config option in blog post

### DIFF
--- a/apps/svelte.dev/content/blog/2025-10-01-whats-new-in-svelte-october-2025.md
+++ b/apps/svelte.dev/content/blog/2025-10-01-whats-new-in-svelte-october-2025.md
@@ -5,7 +5,7 @@ author: Dani Sandoval
 authorURL: https://dreamindani.com
 ---
 
-There were lots of improvements to remote functions this month - including new batching tools and improved performance via lazy discovery. For more info, check out the Docs and PR links in each bullet. Async SSR is also available for those who would like to try it out while it's still experimental. It's included when the `config.experimental.async` setting is enabled.
+There were lots of improvements to remote functions this month - including new batching tools and improved performance via lazy discovery. For more info, check out the Docs and PR links in each bullet. Async SSR is also available for those who would like to try it out while it's still experimental. It's included when the config option in `svelte.config.js` has the `compilerOptions.experimental.async` setting enabled.
 
 We've got a hefty showcase this month too, so let's dive in!
 


### PR DESCRIPTION
Previously, I suggested the wrong setting path to enable `async` in the October blog post. This fixes it to mention that it's under `compilerOptions`.

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
