### PR TITLE
fix: Fixes consistency issues between markdown and code in tutorial\02\04\04

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/04-dimensions/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/04-dimensions/+assets/app-a/src/lib/App.svelte
@@ -10,10 +10,7 @@
 </label>
 
 <div>
-	<span style="font-size: {size}px" contenteditable>
-		edit this text
-	</span>
-
+	<span style="font-size: {size}px" contenteditable>edit this text</span>
 	<span class="size">{w} x {h}px</span>
 </div>
 

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/04-dimensions/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/04-dimensions/+assets/app-b/src/lib/App.svelte
@@ -10,10 +10,7 @@
 </label>
 
 <div bind:clientWidth={w} bind:clientHeight={h}>
-	<span style="font-size: {size}px" contenteditable>
-		edit this text
-	</span>
-
+	<span style="font-size: {size}px" contenteditable>edit this text</span>
 	<span class="size">{w} x {h}px</span>
 </div>
 

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/04-dimensions/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/04-dimensions/index.md
@@ -7,7 +7,7 @@ You can add `clientWidth`, `clientHeight`, `offsetWidth` and `offsetHeight` bind
 ```svelte
 /// file: App.svelte
 <div +++bind:clientWidth={w} bind:clientHeight={h}+++>
-	<span style="font-size: {size}px" contenteditable>{text}</span>
+	<span style="font-size: {size}px" contenteditable>edit this text</span>
 	<span class="size">{w} x {h}px</span>
 </div>
 ```


### PR DESCRIPTION
In the tutorial for Advanced bindings on Dimensions in the Advanced Svelte course, the markdown and the code had inconsistent content. There were differences in line breaks and also a non-existent variable `text` referenced in the markdown. 

I made changes to make the code and markdown look the same as to not take focus away from the learning point at hand.