### PR TITLE
use internal links for first party packages

### DIFF
--- a/apps/svelte.dev/src/routes/packages/PackageCard.svelte
+++ b/apps/svelte.dev/src/routes/packages/PackageCard.svelte
@@ -19,7 +19,11 @@
 		minute: 'numeric'
 	});
 
-	const href = $derived(pkg.homepage || pkg.repo_url || `https://npmjs.org/package/${pkg.name}`);
+	const href = $derived(
+		pkg.homepage?.replace('https://svelte.dev', '') ||
+			pkg.repo_url ||
+			`https://npmjs.org/package/${pkg.name}`
+	);
 </script>
 
 <article>


### PR DESCRIPTION
so that we use client-side nav for e.g. the adapters