### PR TITLE
docs: Add markdoc-svelte package

### DIFF
--- a/apps/svelte.dev/src/lib/packages-meta.ts
+++ b/apps/svelte.dev/src/lib/packages-meta.ts
@@ -125,6 +125,10 @@ const FEATURED: {
 				description: 'Markdown parser that supports Github Flavored Markdown'
 			},
 			{
+				name: 'markdoc-svelte',
+				description: 'Preprocess Markdown and Markdoc files into Svelte components using Markdoc'
+			},
+			{
 				name: '@prismicio/svelte',
 				description: 'Components and helpers to fetch and present Prismic content'
 			},

--- a/apps/svelte.dev/src/lib/server/generated/registry/markdoc-svelte.json
+++ b/apps/svelte.dev/src/lib/server/generated/registry/markdoc-svelte.json
@@ -1,0 +1,12 @@
+{
+	"name": "markdoc-svelte",
+	"npm_description": "A preprocessor to render Markdoc in Svelte",
+	"repo_url": "https://github.com/CollierCZ/markdoc-svelte",
+	"authors": ["colliercz"],
+	"homepage": "https://github.com/CollierCZ/markdoc-svelte#readme",
+	"version": "3.0.0",
+	"downloads": 4,
+	"github_stars": 15,
+	"updated": "2025-06-23T20:22:55.577Z",
+	"svelte_range": "4.x || 5.x"
+}


### PR DESCRIPTION
`markdoc-svelte` is a very useful alternative to `mdsvex` for rendering markdown content. The [Markdoc](https://markdoc.dev/) support also makes it easier to create advanced types of content, like composable blocks for website builders and documentation sites.

After successfully using `mdsvex` for many years, my team has found an even better solution and started using `markdoc-svelte` in several projects lately. This has enabled much more flexibility for dynamic content, compared to MDSveX and MDX. In addition, `markdoc-svelte` has better support for layouts, TypeScript, metadata, and Svelte 5 compared to `mdsvex`.

I hope a low download count is not a blocker for adding new, high quality packages like this one.

I'm not sure about the optimal order, but think it makes sense to showcase early since markdown and similar content types are very common. Perhaps this could even be added as number 2 or 3 to be visible above the fold, since the package is a solid alternative to `mdsvex`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
