### PR TITLE
fix: Changes wording from stop to pause

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/08-script-module/02-module-exports/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/08-script-module/02-module-exports/+assets/app-b/src/lib/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import AudioPlayer, { stopAll } from './AudioPlayer.svelte';
+	import AudioPlayer, { pauseAll } from './AudioPlayer.svelte';
 	import { tracks } from './tracks.js';
 </script>
 
@@ -8,8 +8,8 @@
 		<AudioPlayer {...track} />
 	{/each}
 
-	<button onclick={stopAll}>
-		stop all
+	<button onclick={pauseAll}>
+		pause all
 	</button>
 </div>
 

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/08-script-module/02-module-exports/+assets/app-b/src/lib/AudioPlayer.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/08-script-module/02-module-exports/+assets/app-b/src/lib/AudioPlayer.svelte
@@ -1,7 +1,7 @@
 <script module>
 	let current;
 
-	export function stopAll() {
+	export function pauseAll() {
 		current?.pause();
 	}
 </script>

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/08-script-module/02-module-exports/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/08-script-module/02-module-exports/index.md
@@ -2,25 +2,25 @@
 title: Exports
 ---
 
-Anything exported from a `module` script block becomes an export from the module itself. Let's export a `stopAll` function:
+Anything exported from a `module` script block becomes an export from the module itself. Let's export a `pauseAll` function:
 
 ```svelte
 /// file: AudioPlayer.svelte
 <script module>
 	let current;
 
-+++	export function stopAll() {
++++	export function pauseAll() {
 		current?.pause();
 	}+++
 </script>
 ```
 
-We can now import `stopAll` in `App.svelte`...
+We can now import `pauseAll` in `App.svelte`...
 
 ```svelte
 /// file: App.svelte
 <script>
-	import AudioPlayer, +++{ stopAll }+++ from './AudioPlayer.svelte';
+	import AudioPlayer, +++{ pauseAll }+++ from './AudioPlayer.svelte';
 	import { tracks } from './tracks.js';
 </script>
 ```
@@ -34,8 +34,8 @@ We can now import `stopAll` in `App.svelte`...
 		<AudioPlayer {...track} />
 	{/each}
 
-+++	<button onclick={stopAll}>
-		stop all
++++	<button onclick={pauseAll}>
+		pause all
 	</button>+++
 </div>
 ```


### PR DESCRIPTION
As the word 'stop' is usually connected with stopping playback and resetting the playhead, I think the function we implement here should be called `pauseAll`. The implemented function allows resuming playback from where it was _paused_ and it even calls a function named `pause()`. Yes, I know this is nitpicky ... but I'm an audio guy 😅