### PR TITLE
fix headings

### DIFF
--- a/packages/site-kit/src/lib/markdown/utils.ts
+++ b/packages/site-kit/src/lib/markdown/utils.ts
@@ -15,7 +15,7 @@ export const SHIKI_LANGUAGE_MAP = {
 };
 
 export function is_in_code_block(body: string, index: number) {
-	const code_blocks = [...body.matchAll(/```.*\n(.|\n)+```/gm)].map((match) => {
+	const code_blocks = [...body.matchAll(/(`{3,}).*\n(.|\n)+?\1/gm)].map((match) => {
 		return [match.index ?? 0, match[0].length + (match.index ?? 0)] as const;
 	});
 


### PR DESCRIPTION
#1587 introduced a bad regex — we need the `?` to make the pattern non-greedy. Without it, we're missing headings — https://svelte.dev/docs/kit/load currently looks like this...

<img width="155" height="142" alt="image" src="https://github.com/user-attachments/assets/7764f7ba-d9d7-4991-84e9-93485328a7d7" />

...when it should look like this:

<img width="227" height="630" alt="image" src="https://github.com/user-attachments/assets/9913f75b-5ec3-42a6-b83f-bf51e62f88c6" />

I also changed the hard-coded three backticks to a minimum of three, so that we can potentially do this sort of thing in future:

`````
````md
this is a code fence:

```js
console.log('woooo!');
```
````
`````