### PR TITLE
fix: bug in reactive classes tutorial (app b)

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/01-advanced-reactivity/02-reactive-classes/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/01-advanced-reactivity/02-reactive-classes/+assets/app-b/src/lib/App.svelte
@@ -12,8 +12,8 @@
 		}
 
 		embiggen(amount) {
-			this.width += amount;
-			this.height += amount;
+			this.width = Math.min(MAX_SIZE, this.width + amount);
+			this.height = Math.min(MAX_SIZE, this.height + amount);
 		}
 	}
 


### PR DESCRIPTION
Issue #443

Make sure the embiggen button never embiggens rectangle dimensions beyond ```MAX_SIZE```.

Note: the same bug exists in "app a" but I don't understand why there are two apps in the first place, so I chose one randomly. Also, I checked the documentation repo and I couldn't find the tutorials in the directory tree, so sorry if the PR is in the wrong place.
