### PR TITLE
Add black background color to App component

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/+assets/app-b/src/lib/App.svelte
@@ -19,5 +19,6 @@
 		width: 100%;
 		height: 100%;
 		padding: 1rem;
+		background-color: black;
 	}
 </style>


### PR DESCRIPTION
The default tutorial looks like this: 
<img width="1339" height="1219" alt="image" src="https://github.com/user-attachments/assets/2aef0da4-12f2-4921-b8dd-9625a7b3f2fd" />

This is a tiny change so the div has a background and its easier to see and understand where the mouse tracking would happen:
<img width="1335" height="1219" alt="image" src="https://github.com/user-attachments/assets/a70c70c2-1dd7-4506-913a-e98c89424bff" />
