### PR TITLE
fix: Add 'y' after y-coordinate in tutorial [Basic Svelte/Events/DOM events]

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/index.md
@@ -7,7 +7,7 @@ As we've briefly seen already, you can listen to any DOM event on an element (su
 ```svelte
 /// file: App.svelte
 <div +++onpointermove={onpointermove}+++>
-	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}
+	The pointer is at {Math.round(m.x)} x {Math.round(m.y)} y
 </div>
 ```
 
@@ -16,6 +16,6 @@ Like with any other property where the name matches the value, we can use the sh
 ```svelte
 /// file: App.svelte
 <div +++{onpointermove}+++>
-	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}
+	The pointer is at {Math.round(m.x)} x {Math.round(m.y)} y
 </div>
 ```


### PR DESCRIPTION
Update text to show the letter 'y' after the y-coordinate.

Was going through the tutorial and noticed the missing letter 'y' after the y-coordinate.

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
