### PR TITLE
feat: use css media query for default theming

### DIFF
--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/AppControls.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/AppControls.svelte
@@ -294,6 +294,12 @@
 	.icon:disabled {
 		color: #ccc;
 
+		:root:not(.light) & {
+			@media (prefers-color-scheme: dark) {
+				color: #555;
+			}
+		}
+
 		:root.dark & {
 			color: #555;
 		}

--- a/apps/svelte.dev/src/routes/_home/Hero.svelte
+++ b/apps/svelte.dev/src/routes/_home/Hero.svelte
@@ -63,6 +63,23 @@
 				radial-gradient(circle at 40% 30%, rgb(235, 243, 249), rgb(214, 222, 228));
 		}
 
+		:root:not(.light) &::before {
+			@media (prefers-color-scheme: dark) {
+				background: linear-gradient(to bottom, transparent, var(--sk-bg-1)),
+					radial-gradient(
+						64.14% 72.25% at 47.58% 31.75%,
+						hsl(209deg 6% 47% / 52%) 0%,
+						hsla(0, 0%, 100%, 0) 100%
+					),
+					linear-gradient(
+						92.4deg,
+						hsl(210, 7%, 16%) 14.67%,
+						hsl(0deg 0% 0% / 48%) 54.37%,
+						hsla(207, 22%, 13%, 0.62) 92.49%
+					),
+					linear-gradient(0deg, hsl(204, 38%, 20%), hsl(204, 10%, 90%));
+			}
+		}
 		:root.dark &::before {
 			background: linear-gradient(to bottom, transparent, var(--sk-bg-1)),
 				radial-gradient(

--- a/apps/svelte.dev/src/routes/docs/[topic]/[...path]/+layout.svelte
+++ b/apps/svelte.dev/src/routes/docs/[topic]/[...path]/+layout.svelte
@@ -42,6 +42,11 @@
 	.toc-container {
 		background: var(--sk-bg-2);
 		display: none;
+		:root:not(.light) & {
+			@media (prefers-color-scheme: dark) {
+				background: var(--sk-bg-0);
+			}
+		}
 
 		:root.dark & {
 			background: var(--sk-bg-0);

--- a/apps/svelte.dev/src/routes/packages/PackageCard.svelte
+++ b/apps/svelte.dev/src/routes/packages/PackageCard.svelte
@@ -146,6 +146,12 @@
 
 		min-height: 16em;
 
+		:root:not(.light) & {
+			@media (prefers-color-scheme: dark) {
+				background-color: var(--sk-bg-3);
+			}
+		}
+
 		:root.dark & {
 			background-color: var(--sk-bg-3);
 		}
@@ -232,6 +238,13 @@
 		.logo {
 			width: 3rem;
 			height: 3rem;
+
+			:root:not(.light) &[alt='drizzle logo'],
+			:root:not(.light) &[alt='paraglide logo'] {
+				@media (prefers-color-scheme: dark) {
+					filter: invert(1);
+				}
+			}
 
 			:root.dark &[alt='drizzle logo'],
 			:root.dark &[alt='paraglide logo'] {

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/Loading.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/Loading.svelte
@@ -181,6 +181,14 @@
 		height: 10rem;
 	}
 
+	@media (prefers-color-scheme: dark) {
+		.loading {
+			--faded: #444;
+			--progress: #555;
+			--cutout: var(--sk-bg-2);
+		}
+	}
+
 	:global(.dark) .loading {
 		--faded: #444;
 		--progress: #555;

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -299,6 +299,11 @@
 					&.remove {
 						--color: rgba(255, 0, 0, 0.1);
 
+						:root:not(.light) & {
+							@media (prefers-color-scheme: dark) {
+								--color: rgba(255, 0, 0, 0.27);
+							}
+						}
 						:root.dark & {
 							--color: rgba(255, 0, 0, 0.27);
 						}

--- a/packages/site-kit/src/lib/components/ThemeToggle.svelte
+++ b/packages/site-kit/src/lib/components/ThemeToggle.svelte
@@ -41,6 +41,11 @@
 	.icon {
 		mask-image: url(icons/theme-dark);
 		mask-size: 2rem;
+		:root:not(.light) & {
+			@media (prefers-color-scheme: dark) {
+				mask-image: url(icons/theme-light);
+			}
+		}
 
 		:root.dark & {
 			mask-image: url(icons/theme-light);

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -211,6 +211,11 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			background: linear-gradient(to top, rgba(0, 0, 0, 0.05), transparent);
 		}
 
+		:root:not(.light) & {
+			@media (prefers-color-scheme: dark) {
+				background-color: var(--sk-bg-3);
+			}
+		}
 		:root.dark & {
 			background-color: var(--sk-bg-3);
 		}
@@ -341,6 +346,12 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			background: url(../branding/svelte.svg) no-repeat 0 50% / calc(100% - var(--padding-right))
 				auto;
 			padding: 0 var(--padding-right) 0 calc(var(--sk-page-padding-side) + 0rem);
+
+			:root:not(.light) & {
+				@media (prefers-color-scheme: dark) {
+					background-image: url(../branding/svelte-dark.svg);
+				}
+			}
 
 			:root.dark & {
 				background-image: url(../branding/svelte-dark.svg);

--- a/packages/site-kit/src/lib/styles/tokens/colours.css
+++ b/packages/site-kit/src/lib/styles/tokens/colours.css
@@ -43,6 +43,44 @@
 	/* Misc */
 	--sk-scrollbar: rgba(0, 0, 0, 0.3);
 	--sk-shadow: drop-shadow(0px 0px 14px rgba(0, 0, 0, 0.1));
+
+	&:not(.light) {
+		@media (prefers-color-scheme: dark) {
+			color-scheme: dark;
+
+			--sk-bg-hue: 220;
+
+			/* Foreground colours */
+			--sk-fg-1: hsl(var(--sk-bg-hue), 2%, 90%);
+			--sk-fg-2: hsl(var(--sk-bg-hue), 3%, 80%);
+			--sk-fg-3: hsl(var(--sk-bg-hue), 5%, 65%);
+			--sk-fg-4: hsl(var(--sk-bg-hue), 5%, 55%);
+			--sk-fg-accent: hsl(12, 94%, 62%);
+
+			/* Background colours */
+			--sk-bg-0: hsl(var(--sk-bg-hue), 8%, 10%); /* docs sidebar (dark mode only) */
+			--sk-bg-1: hsl(var(--sk-bg-hue), 10%, 12%);
+			--sk-bg-2: hsl(var(--sk-bg-hue), 12%, 14%);
+			--sk-bg-3: hsl(var(--sk-bg-hue), 14%, 16%);
+			--sk-bg-4: hsl(var(--sk-bg-hue), 15%, 21%);
+			--sk-bg-accent: hsl(15, 100%, 35%);
+			--sk-bg-highlight: hsl(60, 100%, 15%);
+
+			/* Border colour */
+			--sk-border: hsl(var(--sk-bg-hue), 15%, 22%);
+
+			/* Syntax highlighting */
+			--shiki-color-text: hsl(45, 7%, 75%);
+			--shiki-token-comment: hsl(0, 0%, 55%);
+			--shiki-token-keyword: hsl(204, 88%, 65%);
+			--shiki-token-function: hsl(19, 67%, 75%);
+			--shiki-token-string: hsl(41, 37%, 68%);
+
+			/* Misc */
+			--sk-scrollbar: rgba(255, 255, 255, 0.3);
+			--sk-shadow: drop-shadow(1px 2px 16px rgba(0, 0, 0, 0.5));
+		}
+	}
 }
 
 :root.dark {

--- a/packages/site-kit/src/lib/styles/tokens/typography.css
+++ b/packages/site-kit/src/lib/styles/tokens/typography.css
@@ -49,6 +49,12 @@
 		}
 	}
 
+	&:not(.light) {
+		@media (prefers-color-scheme: dark) {
+			-webkit-font-smoothing: antialiased;
+		}
+	}
+
 	&.dark {
 		-webkit-font-smoothing: antialiased;
 	}

--- a/packages/site-kit/src/lib/styles/utils/buttons.css
+++ b/packages/site-kit/src/lib/styles/utils/buttons.css
@@ -13,6 +13,21 @@
 	--sk-raised-width: 1px 2px 2px 1px;
 	--sk-raised-active-width: 2px 1px 1px 2px;
 
+	&:not(.light) {
+		@media (prefers-color-scheme: dark) {
+			--sk-raised-highlight: hsl(var(--sk-bg-hue), 15%, 32%);
+			--sk-raised-shadow: var(--sk-bg-3);
+
+			/* raised buttons */
+			--sk-raised-color: var(--sk-raised-border) var(--sk-raised-shadow) var(--sk-raised-shadow)
+				var(--sk-raised-border);
+			--sk-raised-hover-color: var(--sk-raised-highlight) var(--sk-raised-shadow)
+				var(--sk-raised-shadow) var(--sk-raised-highlight);
+			--sk-raised-active-color: var(--sk-raised-shadow) var(--sk-raised-highlight)
+				var(--sk-raised-highlight) var(--sk-raised-shadow);
+		}
+	}
+
 	&.dark {
 		--sk-raised-highlight: hsl(var(--sk-bg-hue), 15%, 32%);
 		--sk-raised-shadow: var(--sk-bg-3);
@@ -41,6 +56,17 @@
 			hsla(12, 93%, 30%);
 		background: var(--sk-bg-accent);
 		color: white;
+
+		:root:not(.light) & {
+			@media (prefers-color-scheme: dark) {
+				--sk-raised-color: hsla(12, 93%, 60%) hsla(12, 93%, 30%) hsla(12, 93%, 30%)
+					hsla(12, 93%, 60%);
+				--sk-raised-hover-color: hsla(12, 93%, 65%) hsla(12, 93%, 27%) hsla(12, 93%, 27%)
+					hsla(12, 93%, 65%);
+				--sk-raised-active-color: hsla(12, 93%, 25%) hsla(12, 93%, 70%) hsla(12, 93%, 70%)
+					hsla(12, 93%, 25%);
+			}
+		}
 
 		:root.dark & {
 			--sk-raised-color: hsla(12, 93%, 60%) hsla(12, 93%, 30%) hsla(12, 93%, 30%) hsla(12, 93%, 60%);


### PR DESCRIPTION
Today if you have dark mode as system preference and load svelte.dev with Javascript disabled you'll get the Light mode instead. This changes this by using the css media query to set the default in case there's no dark/light class on the body.

There's a bit of duplication but I don't think there's another way to do it unfortunately.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
