### PR TITLE
fix: size adjustment for GitHub and npm icons 

### DIFF
--- a/apps/svelte.dev/src/routes/packages/PackageCard.svelte
+++ b/apps/svelte.dev/src/routes/packages/PackageCard.svelte
@@ -81,7 +81,7 @@
 	<!-- this is a sibling element so that we don't have links inside links -->
 	{#if !pkg.svAlias}
 		<div class="links">
-			<span style="display: flex;">
+			<span>
 				<a
 					href="https://npmjs.org/package/{pkg.name}"
 					target="_blank"
@@ -190,6 +190,7 @@
 			}
 
 			> span {
+				display: flex;
 				gap: 0.75rem;
 				@media screen and (max-width: 768px) {
 					gap: 1rem;


### PR DESCRIPTION
# Adjust Mobile Icons size 

PR for #1576 
changed to **24x24** according to **WCAG spec**

In Mobile Size:

<img width="308" height="144" alt="Screenshot 2025-11-01 at 18 34 49" src="https://github.com/user-attachments/assets/ca1592dd-b474-4473-99e8-01687675ff0b" />

In Desktop Size:

<img width="438" height="179" alt="Screenshot 2025-11-01 at 18 33 04" src="https://github.com/user-attachments/assets/c84f394b-fbc5-449a-ae55-11151919997f" />


