### PR TITLE
feat(repl): add font size adjustment to editor

### DIFF
--- a/packages/repl/src/lib/Editor/Editor.svelte
+++ b/packages/repl/src/lib/Editor/Editor.svelte
@@ -55,6 +55,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	class="container"
+	style="--editor-font-size: {workspace.fontSize}px"
 	bind:this={container}
 	onpointerdown={() => {
 		workspace.enable_tab_indent();
@@ -120,5 +121,9 @@
 
 	.fake-content {
 		padding: 0 1rem;
+	}
+
+	.container :global(.cm-editor .cm-scroller) {
+		font-size: var(--editor-font-size, var(--sk-font-size-mono));
 	}
 </style>

--- a/packages/repl/src/lib/Input/ComponentSelector.svelte
+++ b/packages/repl/src/lib/Input/ComponentSelector.svelte
@@ -186,6 +186,17 @@
 				/>
 			</label>
 
+			<label class="option">
+				<span>Font Size</span>
+				<input
+					type="number"
+					min="10"
+					max="128"
+					value={workspace.fontSize}
+					onchange={(ev) => (workspace.fontSize = ev.currentTarget.valueAsNumber)}
+				/>
+			</label>
+
 			{#if download}
 				<button onclick={download}>Download app</button>
 			{/if}

--- a/packages/repl/src/lib/Input/ComponentSelector.svelte
+++ b/packages/repl/src/lib/Input/ComponentSelector.svelte
@@ -194,7 +194,7 @@
 					max="128"
 					value={workspace.fontSize}
 					onchange={(ev) => (workspace.fontSize = ev.currentTarget.valueAsNumber)}
-				/>
+				/>px
 			</label>
 
 			{#if download}

--- a/packages/repl/src/lib/Workspace.svelte.ts
+++ b/packages/repl/src/lib/Workspace.svelte.ts
@@ -117,6 +117,7 @@ export class Workspace {
 	#files = $state.raw<Item[]>([]);
 	#current = $state.raw() as File;
 	#vim = $state(false);
+	#fontSize = $state(14);
 	#aliases = $state.raw(undefined) as undefined | Record<string, string>;
 	#tailwind = $state(false);
 
@@ -292,6 +293,7 @@ export class Workspace {
 		untrack(() => {
 			view.setState(this.#get_state(untrack(() => this.#current)));
 			this.vim = localStorage.getItem('vim') === 'true';
+			this.fontSize = Number(localStorage.getItem('fontSize')) || 14;
 		});
 	}
 
@@ -550,6 +552,15 @@ export class Workspace {
 
 			this.states.set(file.name, this.#create_state(file));
 		}
+	}
+
+	get fontSize() {
+		return this.#fontSize;
+	}
+
+	set fontSize(value: number) {
+		this.#fontSize = value;
+		localStorage.setItem('fontSize', value.toString());
 	}
 
 	#create_directories(item: Item) {


### PR DESCRIPTION
<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

Added a font size change feature to the REPL editor. This is necessary to make the code more readable when screen sharing or projecting the Playground for Svelte promotion.
(Since there was no discussion in the issue, it's okay to close it if it doesn't meet your intentions.)

<img width="1023" height="337" alt="image" src="https://github.com/user-attachments/assets/34925fbf-dab8-4003-9436-2f3a16953eb0" />



### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
