### PR TITLE
feat: add editing_constraints for layouts tutorial page

### DIFF
--- a/apps/svelte.dev/content/tutorial/03-sveltekit/02-routing/02-layouts/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/02-routing/02-layouts/index.md
@@ -1,5 +1,6 @@
 ---
 title: Layouts
+editing_constraints: { 'create': ['/src/routes/+layout.svelte'] }
 ---
 
 Different routes of your app will often share common UI. Instead of repeating it in each `+page.svelte` component, we can use a `+layout.svelte` component that applies to all routes in the same directory.


### PR DESCRIPTION
As mentioned in #1657 (2): After attempting to create a file with invalid filename the modal with unclear message pops up - editing_contraints were missing for Layouts file. 

After the fix the correct, expected route is shown when trying to create file with unwanted filename

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ x ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ x ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ x ] This message body should clearly illustrate what problems it solves.
