### PR TITLE
fix: Proper z-indexing on 'Back to main menu' button in mobile

### DIFF
--- a/packages/site-kit/src/lib/nav/MobileMenu.svelte
+++ b/packages/site-kit/src/lib/nav/MobileMenu.svelte
@@ -310,6 +310,7 @@
 		width: 50%;
 		height: 4.8rem;
 		padding: 0 var(--sk-page-padding-side);
+		z-index: 2;
 	}
 
 	.universal .contents,


### PR DESCRIPTION
<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

Fixes #1231 by adding z-index of 2 to mobile nav `back-button`. Also fixes same issue that wasn't mentioned with `Tutorial` submenu headers covering same button.

Before:
<img width="478" height="174" alt="Screenshot 2025-11-17 at 1 22 33 PM" src="https://github.com/user-attachments/assets/c5157a09-5ce6-48b7-8648-51736bf7836e" />

After:
<img width="452" height="158" alt="Screenshot 2025-11-17 at 1 22 22 PM" src="https://github.com/user-attachments/assets/b272361d-dfb9-46e5-87e2-8d8ec48f40d6" />

The `h2` used a z-index of 1, so I just went with 2.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
