### PR TITLE
docs: clarify two-way binding explanation in Numeric inputs tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/06-bindings/01-text-inputs/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/06-bindings/01-text-inputs/index.md
@@ -13,4 +13,4 @@ Instead, we can use the `bind:value` directive:
 <input +++bind:+++value={name}>
 ```
 
-This means that changes to the value of `name` update the input, and changes to the input update `name`.
+This means that as well as changes to `name` updating the `<input>`, changes to the `<input>` will update `name`.


### PR DESCRIPTION
This PR updates a sentence in the Binding/Numeric inputs section of the tutorial to make the explanation clearer and more concise.

The original sentence:

"This means that not only will changes to the value of `name` update the input value, but changes to the input value will update `name`."

is grammatically correct, but its structure can be difficult for non-native English speakers to follow.

I suggest to replace it with:

"This means that changes to the value of `name` update the input, and changes to the input update `name`."

This revision preserves the original meaning while improving readability and accessibility for a wider audience.
