### PR TITLE
docs: clarify $state export warning in universal reactivity tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/06-universal-reactivity/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/06-universal-reactivity/index.md
@@ -26,4 +26,4 @@ Then, update the import declaration in `Counter.svelte`:
 
 Now, when you click any button, all three update simultaneously.
 
-> [!NOTE] You cannot export a `$state` declaration from a module if the declaration is reassigned (rather than just mutated), because the importers would have no way to know about it.
+> [!NOTE] You cannot export a `$state` declaration from a module if the declaration is reassigned (rather than just mutated), because the importers would have no way to know about it and attempting to do so would cause a compilation error since imports cannot be reassigned in JavaScript modules.


### PR DESCRIPTION
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

## Why This Change Helps
- add into warning the technical limitation (JavaScript module imports)
- clearly distinguishes mutation (works) from reassignment (doesn't compile)

I have tried the warning
```
// shared.svelte.js
export let counter = $state(0);

// Counter.svelte
<script>
	import { counter } from './shared.svelte.js';
</script>

<button onclick={() => counter += 1}>
	clicks: {counter.count}
</button>

```
this will throw Error compiling Counter.svelte - Cannot assign to import