### PR TITLE
docs: Highligth in Basic/SvelteEventsComponent/events

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/04-component-events/index.md
@@ -15,8 +15,8 @@ You can pass event handlers to components like any other prop. In `Stepper.svelt
 
 ```svelte
 /// file: Stepper.svelte
-<button +++onclick={decrement}+++>-1</button>
-<button +++onclick={increment}+++>+1</button>
+<button +++onclick={decrement}+++ >-1</button>
+<button +++onclick={increment}+++ >+1</button>
 ```
 
 In `App.svelte`, define the handlers:


### PR DESCRIPTION
**Related:** Issue #1722

Small issue in https://svelte.dev/tutorial/svelte/component-events
<img width="1350" height="505" alt="Image" src="https://github.com/user-attachments/assets/187249db-c786-40b9-a0dd-1a988374fa20" />

The docs highlight parts of HTML that do not change, `>-1</` and `>+1</` these don't need Highlight.

Happy new year!
