### PR TITLE
docs: enhance note on spread props for implicit props

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/03-props/03-spread-props/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/03-props/03-spread-props/index.md
@@ -40,3 +40,9 @@ We _could_ fix it by adding the prop...
 > ```js
 > console.log(stuff.name, stuff.version, stuff.description, stuff.website);
 > ```
+>
+> However, props may include special implicit values like [`children`](https://svelte.dev/tutorial/svelte/implicit-snippet-props). To support this, always prefer destructuring props to be explicit about your selection. This is important when the props are reused as-is for nested components.
+>
+> ```js
+> let { children, ...props } = $props();
+> ```


### PR DESCRIPTION
Emphasize the importance of destructuring props for nested components, particularly when implicit props such as children may be present.

When forgoing the destructuring, `children` is included in the value when there are child elements. Spreading these on a child component, which has its own children element, causes conflict and is hard to debug due to the implicit nature of this (magic).

I've added this note while debugging some issues with an SVG-based component, where nearly every prop needed to be forwarded, but also needs a lot of different child elements conditionally.

I acknowledge that this is probably a non-issue for experienced Svelte devs, but this stumped me for quite some time as someone primarily working with Angular & Vue. Please feel free to close this if this is redundant.

<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
