### PR TITLE
Store tailwind option when saving playground apps

### DIFF
--- a/apps/svelte.dev/src/lib/db/gist.js
+++ b/apps/svelte.dev/src/lib/db/gist.js
@@ -38,13 +38,14 @@ export async function list(user, { offset, search }) {
 
 /**
  * @param {User} user
- * @param {Pick<Gist, 'name'|'files'>} gist
+ * @param {Pick<Gist, 'name'|'files'|'tailwind'>} gist
  * @returns {Promise<Gist>}
  */
 export async function create(user, gist) {
 	const { data, error } = await client.rpc('gist_create', {
 		name: gist.name,
 		files: gist.files,
+		tailwind: gist.tailwind ?? false,
 		userid: user.id
 	});
 
@@ -62,7 +63,7 @@ export async function create(user, gist) {
 export async function read(id) {
 	const { data, error } = await client
 		.from('gist')
-		.select('id,name,files,userid')
+		.select('id,name,files,tailwind,userid')
 		.eq('id', id)
 		.is('deleted_at', null);
 
@@ -73,7 +74,7 @@ export async function read(id) {
 /**
  * @param {User} user
  * @param {string} gistid
- * @param {Pick<Gist, 'name'|'files'>} gist
+ * @param {Pick<Gist, 'name'|'files'|'tailwind'>} gist
  * @returns {Promise<Gist>}
  */
 export async function update(user, gistid, gist) {
@@ -81,6 +82,7 @@ export async function update(user, gistid, gist) {
 		gist_id: gistid,
 		gist_name: gist.name,
 		gist_files: gist.files,
+		gist_tailwind: gist.tailwind ?? false,
 		gist_userid: user.id
 	});
 

--- a/apps/svelte.dev/src/lib/db/types.d.ts
+++ b/apps/svelte.dev/src/lib/db/types.d.ts
@@ -18,5 +18,7 @@ export interface Gist {
 	id: string;
 	name: string;
 	owner: UserID;
+	/** Whether Tailwind is enabled for this playground app */
+	tailwind?: boolean;
 	files: Array<{ name: string; type: string; source: string }>;
 }

--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/+page.svelte
@@ -54,7 +54,7 @@
 			repl?.set({
 				// TODO make this munging unnecessary (using JSON instead of structuredClone for better browser compat)
 				files: JSON.parse(JSON.stringify(data.gist.components)).map(munge),
-				tailwind: false // TODO
+				tailwind: data.gist.tailwind ?? false
 			});
 
 			modified = false;

--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/AppControls.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/AppControls.svelte
@@ -56,7 +56,7 @@
 	async function fork(intentWasSave: boolean) {
 		saving = true;
 
-		const { files } = repl.toJSON() as { files: File[] };
+		const { files, tailwind } = repl.toJSON() as { files: File[]; tailwind?: boolean };
 
 		try {
 			const r = await fetch(`/playground/create.json`, {
@@ -67,6 +67,7 @@
 				},
 				body: JSON.stringify({
 					name,
+					tailwind: tailwind ?? false,
 					files: files.map((file) => ({
 						name: file.name,
 						source: file.contents
@@ -122,7 +123,7 @@
 		try {
 			// Send all files back to API
 			// ~> Any missing files are considered deleted!
-			const { files } = repl.toJSON() as { files: File[] };
+			const { files, tailwind } = repl.toJSON() as { files: File[]; tailwind?: boolean };
 
 			const r = await fetch(`/playground/save/${gist.id}.json`, {
 				method: 'PUT',
@@ -132,6 +133,7 @@
 				},
 				body: JSON.stringify({
 					name,
+					tailwind: tailwind ?? false,
 					files: files.map((file) => ({
 						name: file.name,
 						source: file.contents

--- a/apps/svelte.dev/src/routes/(authed)/playground/[id]/embed/+page.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/playground/[id]/embed/+page.svelte
@@ -33,7 +33,7 @@
 		if (!hash) {
 			repl?.set({
 				files: data.gist.components.map(munge),
-				tailwind: false // TODO
+				tailwind: data.gist.tailwind ?? false
 			});
 
 			return;

--- a/apps/svelte.dev/src/routes/(authed)/playground/api/[id].json/+server.ts
+++ b/apps/svelte.dev/src/routes/(authed)/playground/api/[id].json/+server.ts
@@ -20,6 +20,7 @@ export async function GET({ fetch, params }) {
 			id: params.id,
 			name: example.title,
 			owner: null,
+			tailwind: false,
 			relaxed: false, // TODO is this right? EDIT: It was example.relaxed before, which no example return to my knowledge. By @PuruVJ
 			components: example.components
 		});
@@ -55,6 +56,7 @@ export async function GET({ fetch, params }) {
 		name: app.name,
 		// @ts-ignore
 		owner: app.userid,
+		tailwind: app.tailwind ?? false,
 		relaxed: false,
 		components: app.files!.map((file) => {
 			const dot = file.name.lastIndexOf('.');


### PR DESCRIPTION
## Summary
- send tailwind flag when creating/saving playground apps
- persist/retrieve tailwind via gist create/update/read
- hydrate repl tailwind from saved gist in playground + embed

## Caveat
- Assumes DB schema/RPCs already support `gist.tailwind` and parameters on `gist_create`/`gist_update`; otherwise those DB changes are still needed.

Closes #1220
