### PR TITLE
feat: Make the terminal on tutorials resizable with SplitPane

### DIFF
--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/Output.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/Output.svelte
@@ -10,9 +10,10 @@
 	import Chrome from './Chrome.svelte';
 	import Loading from './Loading.svelte';
 	import { adapter_state, subscribe, reset } from './adapter.svelte';
-	import { SplitPane } from '@rich_harris/svelte-split-pane';
+	import { SplitPane, type Length } from '@rich_harris/svelte-split-pane';
 	import type { Exercise } from '$lib/tutorial';
 	import type { Workspace } from '@sveltejs/repl/workspace';
+	import { Spring } from 'svelte/motion';
 
 	interface Props {
 		exercise: Exercise;
@@ -25,6 +26,9 @@
 	let iframe = $state() as HTMLIFrameElement;
 	let loading = $state(true);
 	let terminal_visible = $state(false);
+
+	let last_pos = 20;
+	let pos = Spring.of(() => (terminal_visible ? last_pos : 100));
 
 	// reset `path` to `exercise.path` each time, but allow it to be controlled by the iframe
 	// svelte-ignore state_referenced_locally
@@ -125,6 +129,10 @@
 		set_iframe_src(adapter_state.base + path);
 	}}
 	toggle_terminal={() => {
+		if (terminal_visible) {
+			last_pos = pos.current;
+		}
+
 		terminal_visible = !terminal_visible;
 	}}
 	change={(e) => {
@@ -142,7 +150,7 @@
 		type="vertical"
 		disabled={!terminal_visible}
 		max={terminal_visible ? '80%' : '100%'}
-		pos={terminal_visible ? '20%' : '100%'}
+		bind:pos={() => (pos.current + '%') as Length, (v) => pos.set(parseFloat(v), { instant: true })}
 	>
 		{#snippet a()}
 			{#if browser}

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
@@ -6,10 +6,14 @@
 	import Chrome from './Chrome.svelte';
 	import Loading from './Loading.svelte';
 	import { adapter_state, update } from './adapter.svelte';
-	import { SplitPane } from '@rich_harris/svelte-split-pane';
+	import { SplitPane, type Length } from '@rich_harris/svelte-split-pane';
+	import { Spring } from 'svelte/motion';
 
 	let terminal_visible = $state(false);
 	let logs = $state<Log[]>([]);
+
+	let last_pos = 20;
+	let pos = Spring.of(() => (terminal_visible ? last_pos : 100));
 </script>
 
 <Chrome
@@ -23,7 +27,13 @@
 			contents: ''
 		});
 	}}
-	toggle_terminal={() => (terminal_visible = !terminal_visible)}
+	toggle_terminal={() => {
+		if (terminal_visible) {
+			last_pos = pos.current;
+		}
+
+		terminal_visible = !terminal_visible;
+	}}
 />
 
 <div class="content">
@@ -32,7 +42,7 @@
 		type="vertical"
 		disabled={!terminal_visible}
 		max={terminal_visible ? '80%' : '100%'}
-		pos={terminal_visible ? '20%' : '100%'}
+		bind:pos={() => (pos.current + '%') as Length, (v) => pos.set(parseFloat(v), { instant: true })}
 	>
 		{#snippet a()}
 			{#if browser}


### PR DESCRIPTION
<!-- If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories (at https://github.com/sveltejs/svelte or https://github.com/sveltejs/kit, or example). -->

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time.
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.

Closes #1740 by wrapping the viewer and terminal in a SplitPane. 

Quick demo:
[screen-capture.webm](https://github.com/user-attachments/assets/6a6ef722-313f-4241-9c22-d2781cffb621)

Update (see comments): Fixes https://github.com/sveltejs/svelte.dev/issues/624
