### PR TITLE
fix: remove playground links from `llms.txt`

### DIFF
--- a/apps/svelte.dev/src/lib/server/llms.ts
+++ b/apps/svelte.dev/src/lib/server/llms.ts
@@ -25,6 +25,10 @@ const defaults: MinimizeOptions = {
 	remove_prettier_ignore: false
 };
 
+export function remove_playground_links(content: string): string {
+	return content.replaceAll(/\[([^\]]+)\]\((https:\/\/svelte\.dev)?\/playground.+\)/g, '$1');
+}
+
 export function generate_llm_content(options: GenerateLlmContentOptions): string {
 	let content = '';
 

--- a/apps/svelte.dev/src/routes/docs/[topic]/[...path]/llms.txt/+server.ts
+++ b/apps/svelte.dev/src/routes/docs/[topic]/[...path]/llms.txt/+server.ts
@@ -1,6 +1,10 @@
 import { error } from '@sveltejs/kit';
 import { docs } from '$lib/server/content.js';
-import { generate_llm_content, get_documentation_title } from '$lib/server/llms';
+import {
+	generate_llm_content,
+	get_documentation_title,
+	remove_playground_links
+} from '$lib/server/llms';
 import { topics } from '$lib/topics';
 
 export const prerender = true;
@@ -19,7 +23,7 @@ export function GET({ params }) {
 			error(404, 'Not Found');
 		}
 
-		return new Response(page.body, {
+		return new Response(remove_playground_links(page.body), {
 			status: 200,
 			headers: {
 				'Content-Type': 'text/plain; charset=utf-8',
@@ -34,7 +38,7 @@ export function GET({ params }) {
 		}
 
 		const prefix = `<SYSTEM>${get_documentation_title(topic)}</SYSTEM>`;
-		const content = `${prefix}\n\n${generate_llm_content({ topics: [topic] })}`;
+		const content = `${prefix}\n\n${remove_playground_links(generate_llm_content({ topics: [topic] }))}`;
 
 		return new Response(content, {
 			status: 200,

--- a/apps/svelte.dev/src/routes/llms-full.txt/+server.ts
+++ b/apps/svelte.dev/src/routes/llms-full.txt/+server.ts
@@ -1,4 +1,4 @@
-import { generate_llm_content } from '$lib/server/llms';
+import { generate_llm_content, remove_playground_links } from '$lib/server/llms';
 import { topics } from '$lib/topics';
 
 export const prerender = true;
@@ -6,7 +6,7 @@ export const prerender = true;
 export function GET() {
 	const content = `<SYSTEM>This is the full developer documentation for Svelte and SvelteKit.</SYSTEM>\n\n${generate_llm_content({ topics })}`;
 
-	return new Response(content, {
+	return new Response(remove_playground_links(content), {
 		status: 200,
 		headers: {
 			'Content-Type': 'text/plain; charset=utf-8',

--- a/apps/svelte.dev/src/routes/llms-medium.txt/+server.ts
+++ b/apps/svelte.dev/src/routes/llms-medium.txt/+server.ts
@@ -1,4 +1,4 @@
-import { generate_llm_content } from '$lib/server/llms';
+import { generate_llm_content, remove_playground_links } from '$lib/server/llms';
 import { topics } from '$lib/topics';
 
 export function GET() {
@@ -35,7 +35,7 @@ export function GET() {
 	});
 	const content = `<SYSTEM>This is the abridged developer documentation for Svelte and SvelteKit.</SYSTEM>\n\n${main_content}`;
 
-	return new Response(content, {
+	return new Response(remove_playground_links(content), {
 		status: 200,
 		headers: {
 			'Content-Type': 'text/plain; charset=utf-8',

--- a/apps/svelte.dev/src/routes/llms.txt/+server.ts
+++ b/apps/svelte.dev/src/routes/llms.txt/+server.ts
@@ -1,4 +1,4 @@
-import { get_documentation_title } from '$lib/server/llms';
+import { get_documentation_title, remove_playground_links } from '$lib/server/llms';
 import { topics } from '$lib/topics';
 import template from './template.md?raw';
 
@@ -14,7 +14,7 @@ export function GET() {
 
 	const content = template.replace('%PACKAGE_DOCS%', package_docs.join('\n'));
 
-	return new Response(content, {
+	return new Response(remove_playground_links(content), {
 		headers: {
 			'Content-Type': 'text/plain; charset=utf-8',
 			'Cache-Control': 'public, max-age=3600'


### PR DESCRIPTION
There's no reason to have playground links in the llms.txt since they can't follow them AND they consume a shitload of tokens. This removes all the links to the playground before returning the content.

This will be useful for the MCP server now and for the SKILL we plan to add to the docs later.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
