### PR TITLE
fix: generate editing constraints automatically

### DIFF
--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/+page.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/+page.svelte
@@ -336,7 +336,7 @@
 
 									{#if mobile && show_filetree}
 										<div class="mobile-filetree">
-											<Filetree mobile exercise={data.exercise} {workspace} />
+											<Filetree mobile exercise={data.exercise} {workspace} {constraints} />
 										</div>
 									{/if}
 								</section>

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/filetree/Filetree.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/filetree/Filetree.svelte
@@ -79,7 +79,7 @@
 				return;
 			}
 
-			if (!constraints.can_remove.has(to_rename.name)) {
+			if (exercise.a[to_rename.name] && !constraints.can_remove.has(to_rename.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be removed in this exercise:\n' +
 					Array.from(constraints.can_remove).join('\n');
@@ -91,7 +91,7 @@
 		},
 
 		remove: async (file) => {
-			if (!constraints.can_remove.has(file.name)) {
+			if (exercise.a[file.name] && !constraints.can_remove.has(file.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be deleted in this tutorial chapter:\n' +
 					Array.from(constraints.can_remove).join('\n');


### PR DESCRIPTION
fixes the second part of #1657 — we now automatically generate the list of which files and folders can be created/removed, while preserving the ability to add other intermediate files