### PR TITLE
chore: remove Node polyfills reference from modules page

### DIFF
--- a/apps/svelte.dev/src/routes/docs/kit/modules/+page.svelte
+++ b/apps/svelte.dev/src/routes/docs/kit/modules/+page.svelte
@@ -110,13 +110,6 @@
 			['`@sveltejs/kit/node#setResponse`', '/docs/kit/@sveltejs-kit-node#setResponse']
 		],
 		[
-			'sveltejs-kit-node-polyfills-installpolyfills',
-			[
-				'`@sveltejs/kit/node/polyfills#installPolyfills`',
-				'/docs/kit/@sveltejs-kit-node-polyfills#installPolyfills'
-			]
-		],
-		[
 			'sveltejs-kit-vite-sveltekit',
 			['`@sveltejs/kit/vite#sveltekit`', '/docs/kit/@sveltejs-kit-vite#sveltekit']
 		]


### PR DESCRIPTION
The svelte.dev/docs/kit/modules page references `@sveltejs/kit/node/polyfills` which we're trying to remove in https://github.com/sveltejs/kit/pull/15430

This PR removes that reference so we can get the docs building

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
