### PR TITLE
fix: downgrade @webcontainer/api

### DIFF
--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -30,7 +30,7 @@
 		"@types/d3-geo": "^3.1.0",
 		"@vercel/analytics": "^1.6.1",
 		"@vercel/speed-insights": "^1.3.1",
-		"@webcontainer/api": "^1.6.1",
+		"@webcontainer/api": "^1.1.5",
 		"adm-zip": "^0.5.16",
 		"ansi-to-html": "^0.7.2",
 		"base64-js": "^1.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1(@sveltejs/kit@2.53.2(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.5)(vite@8.0.0-beta.15(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0)))(svelte@5.53.5)(typescript@5.9.3)(vite@8.0.0-beta.15(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0)))(svelte@5.53.5)
       '@webcontainer/api':
-        specifier: ^1.6.1
-        version: 1.6.1
+        specifier: ^1.1.5
+        version: 1.1.5
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
@@ -1861,8 +1861,8 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@webcontainer/api@1.6.1':
-    resolution: {integrity: sha512-2RS2KiIw32BY1Icf6M1DvqSmcon9XICZCDgS29QJb2NmF12ZY2V5Ia+949hMKB3Wno+P/Y8W+sPP59PZeXSELg==}
+  '@webcontainer/api@1.1.5':
+    resolution: {integrity: sha512-qMJyqO+A8+B8JKW/IW9KVQblAiEQwesq7ka6w8pgm6DXKWCQaPVOco4Zo7FxZ09OmBIX+lnXyfKbQzXiORLGJg==}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -4694,7 +4694,7 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@webcontainer/api@1.6.1': {}
+  '@webcontainer/api@1.1.5': {}
 
   abbrev@3.0.1: {}
 


### PR DESCRIPTION
we broke the sveltekit tutorial in #1816 — not sure why, or which precise version is responsible, but the easiest fix is to downgrade `@webcontainer/api` for now