### PR TITLE
fix: prevent JSDoc tag overlap in tooltips (#1043)

### DIFF
--- a/packages/site-kit/src/lib/docs/Tooltip.svelte
+++ b/packages/site-kit/src/lib/docs/Tooltip.svelte
@@ -97,12 +97,17 @@
 
 			.tags {
 				display: grid;
-				grid-template-columns: 8rem 1fr;
+				grid-template-columns: auto 1fr;
+				column-gap: 1rem;
 				align-items: baseline;
 
 				.tag,
 				.param {
 					font: var(--sk-font-mono);
+				}
+
+				.tag {
+					min-width: 8rem;
 				}
 			}
 


### PR DESCRIPTION
Prevents long JSDoc tags (like `@deprecated`) from overlapping with their descriptions by allowing the grid to expand, while preserving the existing `8rem` alignment for other tags.

resolves https://github.com/sveltejs/svelte.dev/issues/1043

### Before

<img width="1423" height="451" alt="1043-before" src="https://github.com/user-attachments/assets/3cc2c6eb-6455-4a57-8068-7661ec4ce3cd" />


### After

<img width="1423" height="451" alt="1043-after" src="https://github.com/user-attachments/assets/1193a102-4058-4884-bae8-bec46dd67e3a" />
