### PR TITLE
fix: render JSDoc @example as block code in tooltips (#1177)

### DIFF
--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -1000,8 +1000,7 @@ async function syntax_highlight({
 				)) {
 					const tag = match[1];
 					let value = match[2];
-
-					let content = `<span class="tag">${tag}</span><span class="value">`;
+					let content = `<div class="tag">${tag}</div><div class="value">`;
 
 					if (tag === '@param' || tag === '@throws') {
 						const words = value.split(' ');
@@ -1019,8 +1018,13 @@ async function syntax_highlight({
 						content += `<span class="param">${param}</span> `;
 					}
 
-					content += marked.parseInline(value);
-					content += '</span>';
+					if (tag === '@example') {
+						content += await render_content_markdown('<twoslash>', value, { check: false });
+					} else {
+						content += marked.parseInline(value);
+					}
+
+					content += '</div>';
 
 					replacements.push({
 						start: match.index,


### PR DESCRIPTION
Enables multi-line rendering and syntax highlighting for `@example` tags in documentation tooltips by using the full markdown renderer.

Resolves:

- https://github.com/sveltejs/svelte.dev/issues/1177

### Before

<img width="1427" height="603" alt="1177-before" src="https://github.com/user-attachments/assets/03e0f0cd-98a2-4bb9-8f6a-cd161d181cc6" />


### After

<img width="1427" height="603" alt="1177-after" src="https://github.com/user-attachments/assets/fd883166-dc49-4bbb-9f8a-b3956f1720ab" />
