### PR TITLE
fix: prevent TS toggle and copy button overlap on iPhone (#1046)

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -179,6 +179,7 @@
 					height: calc(var(--height) - 1rem);
 					outline-offset: 0;
 					padding: 0 0.6rem;
+					width: fit-content;
 
 					&::before,
 					&::after {


### PR DESCRIPTION
Fixes a visual layout bug on iPhones where the JS/TS toggle and copy-to-clipboard button in code blocks overlap, making them impossible to click. 

Fixes [#1046](https://github.com/sveltejs/svelte.dev/issues/1046)

### Before
<img width="331" height="239" alt="image" src="https://github.com/user-attachments/assets/7fea6f16-da1e-42cd-a335-a24d29cac351" />

### After
<img width="337" height="236" alt="image" src="https://github.com/user-attachments/assets/a9161194-fdd3-4585-85ad-69c078e01f7b" />
