### PR TITLE
fix: add role=presentation to silence a11y warnings in tutorials (#1862)

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/+assets/app-a/src/lib/App.svelte
@@ -7,7 +7,7 @@
 	}
 </script>
 
-<div>
+<div role="presentation">
 	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}
 </div>
 

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/+assets/app-b/src/lib/App.svelte
@@ -7,7 +7,7 @@
 	}
 </script>
 
-<div {onpointermove}>
+<div {onpointermove} role="presentation">
 	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}
 </div>
 

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/01-dom-events/index.md
@@ -6,7 +6,7 @@ As we've briefly seen already, you can listen to any DOM event on an element (su
 
 ```svelte
 /// file: App.svelte
-<div +++onpointermove={onpointermove}+++>
+<div +++onpointermove={onpointermove}+++ role="presentation">
 	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}
 </div>
 ```
@@ -15,7 +15,7 @@ Like with any other property where the name matches the value, we can use the sh
 
 ```svelte
 /// file: App.svelte
-<div +++{onpointermove}+++>
+<div +++{onpointermove}+++ role="presentation">
 	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}
 </div>
 ```

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/+assets/app-b/src/lib/App.svelte
@@ -7,6 +7,7 @@
 		m.x = event.clientX;
 		m.y = event.clientY;
 	}}
+	role="presentation"
 >
 	The pointer is at {Math.round(m.x)} x {Math.round(m.y)}
 </div>

--- a/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/05-events/02-inline-handlers/index.md
@@ -20,6 +20,7 @@ You can also declare event handlers inline:
 		m.x = event.clientX;
 		m.y = event.clientY;
 	}+++}
+	role="presentation"
 >
 	The pointer is at {m.x} x {m.y}
 </div>


### PR DESCRIPTION
Fixes `<div> with a pointermove handler must have an ARIA role` warning in [DOM events](https://svelte.dev/tutorial/svelte/dom-events) and [Inline handlers](https://svelte.dev/tutorial/svelte/inline-handlers) tutorials by adding missing `role="presentation"` to `div` elements, following the pattern established in the [Capturing](https://svelte.dev/tutorial/svelte/capturing) lesson.

Fixes #1862

### Before

<img width="1250" height="466" alt="Screenshot From 2026-03-17 11-26-12" src="https://github.com/user-attachments/assets/ea3e2159-1935-4081-868b-99d4ee2aeeb6" />

### After

<img width="1250" height="466" alt="Screenshot From 2026-03-17 11-26-22" src="https://github.com/user-attachments/assets/22da9fb0-9f9b-47e0-aaca-361e5d5b2c2d" />