### PR TITLE
fix: inconsistent margins between blog standfirst and byline (#635)

### DIFF
--- a/apps/svelte.dev/src/routes/blog/[slug]/+page.svelte
+++ b/apps/svelte.dev/src/routes/blog/[slug]/+page.svelte
@@ -24,7 +24,7 @@
 <article>
 	<header>
 		<h1>{data.metadata.title}</h1>
-		<p class="standfirst">{@html data.metadata.description}</p>
+		<p>{@html data.metadata.description}</p>
 		<Byline post={data} />
 	</header>
 
@@ -37,6 +37,12 @@
 		max-width: var(--sk-page-content-width);
 		box-sizing: content-box;
 		margin: 0 auto;
+
+		p {
+			font: var(--sk-font-body-small);
+			color: var(--sk-fg-3);
+			margin: 0 0 0.5em 0;
+		}
 
 		:global {
 			figure {
@@ -103,12 +109,6 @@
 
 	h1 {
 		font: var(--sk-font-h1);
-	}
-
-	.standfirst {
-		font: var(--sk-font-body-small);
-		color: var(--sk-fg-3);
-		margin: 0 0 1em 0;
 	}
 
 	@media (min-width: 960px) {


### PR DESCRIPTION

Align the vertical spacing between the blog post description and byline for consistent layout across listing and slug pages.  

The `.standfirst` class on the slug page was removed because it applied a `1em` bottom margin, while the listing page styles its `<p>` directly with `0.5em`. The slug page now uses a scoped `article p` selector matching the listing page’s approach, ensuring consistent spacing and styling patterns across both pages.

Fixes [#635](https://github.com/sveltejs/svelte.dev/issues/635)

### Before
![before](https://github.com/user-attachments/assets/361e48bc-37b4-4371-aafa-e9c37af24088)

### After
![after](https://github.com/user-attachments/assets/132666f7-e0aa-4642-943a-a748a9d16745)

**_Note:_**  
_A common header component was not extracted because the listing page uses `<h2>` for post previews while the slug page uses `<h1>` for the article title. Extracting a shared component would break the intended semantic order of headings on both pages._  

_Additionally, the `.standfirst` class on the slug page was removed because it applied a `1em` bottom margin, while the listing page styles its `<p>` directly with `0.5em`; moving to a scoped selector keeps consistency amongst components._