### PR TITLE
fix: show first sub-item in "On this page" on mobile (#1860)

### DIFF
--- a/apps/svelte.dev/src/routes/docs/[topic]/[...path]/OnThisPage.svelte
+++ b/apps/svelte.dev/src/routes/docs/[topic]/[...path]/OnThisPage.svelte
@@ -97,7 +97,7 @@
 			}
 
 			/* Only show the title link if it's in the sidebar */
-			li:first-child {
+			& > ul > li:first-child {
 				display: none;
 			}
 
@@ -244,7 +244,7 @@
 					text-indent: 1ch hanging;
 				}
 
-				li:first-child {
+				& > ul > li:first-child {
 					display: list-item;
 				}
 


### PR DESCRIPTION
The CSS selector `li:first-child` in `OnThisPage.svelte` was too broad, incorrectly hiding the first sub-item of every section in the documentation navigation menu on mobile viewports.

Refined the selector to `& > ul > li:first-child` to specifically target only the top-level page title link.

Fixes #1860

### Before

<img width="335" height="541" alt="Screenshot From 2026-03-18 06-45-30" src="https://github.com/user-attachments/assets/24c4f386-80ea-46f2-bcb2-c410cdd006b9" />

### After

<img width="335" height="626" alt="Screenshot From 2026-03-18 06-45-21" src="https://github.com/user-attachments/assets/398edaf7-6185-43d3-b6f5-2a9d2005901c" />
