### PR TITLE
fix: add visual hover feedback to file explorer and chapter menu (#1643)

### DIFF
--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/+page.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/+page.svelte
@@ -447,6 +447,7 @@
 		/* put ellipsis at start */
 		direction: rtl;
 		text-align: left;
+		cursor: pointer;
 	}
 
 	.mobile-filetree {

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/filetree/Item.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/filetree/Item.svelte
@@ -124,11 +124,19 @@
 		background-size: 1.2rem;
 	}
 
+	li:hover {
+		--bg: var(--sk-bg-4);
+	}
+
 	button,
 	input {
 		background-size: 1.2rem 1.2rem;
 		background-position: 0 45%;
 		background-repeat: no-repeat;
+	}
+
+	button {
+		cursor: pointer;
 	}
 
 	:focus-visible {

--- a/packages/site-kit/src/lib/styles/utils/nav.css
+++ b/packages/site-kit/src/lib/styles/utils/nav.css
@@ -12,6 +12,14 @@
 			font: inherit;
 			display: block;
 			user-select: none;
+			cursor: pointer;
+			border-radius: var(--sk-border-radius-inner);
+			padding: 0.2rem 0.5rem 0.2rem 2.2rem;
+			margin-left: -2.2rem;
+
+			&:hover {
+				background-color: var(--sk-bg-4);
+			}
 
 			&::-webkit-details-marker {
 				display: none;
@@ -20,8 +28,9 @@
 			&::before {
 				content: '';
 				position: absolute;
-				top: 0.3rem;
-				left: -2rem;
+				top: 50%;
+				translate: 0 -50%;
+				left: 0.2rem;
 				width: 1.8rem;
 				height: 1.8rem;
 				background: url(icons/chevron) no-repeat 50% 50%;


### PR DESCRIPTION
Adds hover feedback to the tutorial file tree and chapter menu items (`<button>`, `<summary>`).

This uses the standard `--sk-bg-4` highlight from site-kit, matching how other menus in the app behave. No new styling conventions or custom classes were added.

Fixes #1643

### Before

https://github.com/user-attachments/assets/ae041ca6-5efc-4d35-a610-0d123a014259

### After

https://github.com/user-attachments/assets/08e590d9-eda1-48ff-8850-71449a09faf7
