### PR TITLE
fix: missing .env file in environment variables lessons (#1835)

### DIFF
--- a/apps/svelte.dev/src/lib/server/content.ts
+++ b/apps/svelte.dev/src/lib/server/content.ts
@@ -13,6 +13,7 @@ const documents = import.meta.glob<string>('./**/*.md', {
 });
 
 const assets = import.meta.glob<string>(['./**/+assets/**', './**/+assets/**/.env'], {
+	exhaustive: true,
 	eager: true,
 	query: '?url',
 	import: 'default',

--- a/apps/svelte.dev/src/lib/server/content.ts
+++ b/apps/svelte.dev/src/lib/server/content.ts
@@ -12,13 +12,17 @@ const documents = import.meta.glob<string>('./**/*.md', {
 	base: '../../../content'
 });
 
-const assets = import.meta.glob<string>(['./**/+assets/**', './**/+assets/**/.env'], {
-	exhaustive: true,
-	eager: true,
-	query: '?url',
-	import: 'default',
-	base: '../../../content'
-});
+const assets = import.meta.glob<string>(
+	['./**/+assets/**', '!**/node_modules', '!**/.svelte-kit'],
+	{
+		// required to include .env tutorial files
+		exhaustive: true,
+		eager: true,
+		query: '?url',
+		import: 'default',
+		base: '../../../content'
+	}
+);
 
 const registry_docs = import.meta.glob<string>(
 	'../../../src/lib/server/generated/registry/*.json',


### PR DESCRIPTION
No `.env` files were showing up in the Environment Variables lessons of the Advanced SvelteKit tutorial. This PR updates the glob import so that `.env` is correctly included in the build version and visible across all four lessons in this section.

Fixes [#1835](https://github.com/sveltejs/svelte.dev/issues/1835)

### Before
<img width="1915" height="1029" alt="image" src="https://github.com/user-attachments/assets/6bd8fafb-25bf-4df7-b784-d2a22b0b8935" />

### After
<img width="1916" height="1024" alt="image" src="https://github.com/user-attachments/assets/d99ae451-7182-4d87-bc93-454ea858475b" />  

**_Note:_** 
_Verified that the `__data.json` for `env-static-private` route includes the .env file in build_
<img width="370" height="252" alt="image" src="https://github.com/user-attachments/assets/6d82eea1-e44d-419a-a7fd-3f7d2a10a41f" />
