### PR TITLE
fix: use text-wrap: pretty for body text

### DIFF
--- a/packages/site-kit/src/lib/styles/base.css
+++ b/packages/site-kit/src/lib/styles/base.css
@@ -45,6 +45,7 @@ ul,
 ol {
 	font: var(--sk-font-body);
 	margin: 0.5lh 0;
+	text-wrap: pretty;
 
 	&:first-child {
 		margin-top: 0;


### PR DESCRIPTION
## before

<img width="780" height="144" alt="image" src="https://github.com/user-attachments/assets/601dd25e-3599-4a47-bfdb-63a76b2b7d79" />


## after

<img width="776" height="145" alt="image" src="https://github.com/user-attachments/assets/c62320cb-dfa2-4ed5-98a9-ad9956c278df" />
