### PR TITLE
fix TS toggle for codeblocks with a mixture of translated and non-translated files

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -362,12 +362,22 @@
 				display: none;
 			}
 
-			&:has(.ts-toggle:checked) pre:first-of-type {
-				display: none;
+			&:has(.ts-toggle) {
+				pre {
+					display: none;
+				}
+
+				&:has(.ts-toggle:checked) [data-ts] {
+					display: block;
+				}
+
+				&:has(.ts-toggle:checked) [data-ts] {
+					display: block;
+				}
 			}
 
-			&:has(.ts-toggle:not(:checked)) pre:last-of-type {
-				display: none;
+			&:has(.ts-toggle:not(:checked)) [data-js] {
+				display: block;
 			}
 
 			pre {

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -482,15 +482,17 @@ export async function render_content_markdown(
 							? await generate_ts_from_js(source, token.lang, options)
 							: undefined;
 
+					let highlighted = await syntax_highlight({
+						filename,
+						language: token.lang,
+						prelude,
+						source,
+						check,
+						references
+					});
+
 					cached.push(
-						await syntax_highlight({
-							filename,
-							language: token.lang,
-							prelude,
-							source,
-							check,
-							references
-						})
+						highlighted.replace('<pre', converted ? '<pre data-js' : '<pre data-js data-ts')
 					);
 
 					if (converted) {
@@ -500,16 +502,16 @@ export async function render_content_markdown(
 							prelude = prelude.replace(/(\/\/ @filename: .+)\.js$/gm, '$1.ts');
 						}
 
-						cached.push(
-							await syntax_highlight({
-								filename,
-								language,
-								prelude,
-								source: converted,
-								check,
-								references
-							})
-						);
+						highlighted = await syntax_highlight({
+							filename,
+							language,
+							prelude,
+							source: converted,
+							check,
+							references
+						});
+
+						cached.push(highlighted.replace('<pre', '<pre data-ts'));
 					}
 
 					snippets.save(decodedText, cached);


### PR DESCRIPTION
Fixes a small glitch with #1879 — if a codeblock contains a mixture of translated and non-translated files, the `:first-of-type` and `:last-of-type` selectors are brittle