### PR TITLE
fix: use bundler module resolution for twoslash

### DIFF
--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -1115,6 +1115,8 @@ async function syntax_highlight({
 									compilerOptions: {
 										allowJs: true,
 										checkJs: true,
+										module: ts.ModuleKind.ESNext,
+										moduleResolution: ts.ModuleResolutionKind.Bundler,
 										types: ['svelte', '@sveltejs/kit', 'sv', '@sveltejs/sv-utils']
 									}
 								},


### PR DESCRIPTION
Follow-up to #1882.

`moduleResolution: "node10"` (the default) doesn't resolve `.d.mts` files or `exports` in `package.json`, so `sv` and `@sveltejs/sv-utils` types were all `any` in twoslash hovers.