### PR TITLE
fix: prevent overlay flash when closing iOS mobile nav menu (#1548)

### DIFF
--- a/packages/site-kit/src/lib/components/ModalOverlay.svelte
+++ b/packages/site-kit/src/lib/components/ModalOverlay.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 
-	let { onclose }: { onclose?: () => void } = $props();
+	let { onclose, duration = 200 }: { onclose?: () => void; duration?: number } = $props();
 </script>
 
 <div
-	transition:fade={{ duration: 100 }}
+	transition:fade={{ duration }}
 	class="modal-overlay"
 	aria-hidden="true"
 	onclick={onclose}

--- a/packages/site-kit/src/lib/nav/MobileMenu.svelte
+++ b/packages/site-kit/src/lib/nav/MobileMenu.svelte
@@ -10,6 +10,8 @@
 	import type { NavigationLink } from '../types';
 	import ModalOverlay from '../components/ModalOverlay.svelte';
 
+	let transition_duration = 200;
+
 	interface Props {
 		links: NavigationLink[];
 		current: NavigationLink | undefined;
@@ -54,10 +56,10 @@
 	}
 </script>
 
-<ModalOverlay {onclose} />
+<ModalOverlay {onclose} duration={transition_duration} />
 
 <div class="menu" use:trap={{ reset_focus: false }}>
-	<div class="mobile-main-menu" transition:popup={{ duration: 200, easing: quintOut }}>
+	<div class="mobile-main-menu" transition:popup={{ duration: transition_duration, easing: quintOut }}>
 		<div
 			class="menu-background"
 			class:ready

--- a/packages/site-kit/src/lib/nav/MobileMenu.svelte
+++ b/packages/site-kit/src/lib/nav/MobileMenu.svelte
@@ -59,7 +59,10 @@
 <ModalOverlay {onclose} duration={transition_duration} />
 
 <div class="menu" use:trap={{ reset_focus: false }}>
-	<div class="mobile-main-menu" transition:popup={{ duration: transition_duration, easing: quintOut }}>
+	<div
+		class="mobile-main-menu"
+		transition:popup={{ duration: transition_duration, easing: quintOut }}
+	>
 		<div
 			class="menu-background"
 			class:ready


### PR DESCRIPTION
Fixes a visual glitch where the overlay briefly flashes when closing the mobile navigation menu.

The issue was caused by a discrepancy in transition durations between `MobileMenu` and `ModalOverlay`. 

The transition timing has been streamlined by defining it in `MobileMenu` and passing it down as a prop to `ModalOverlay`. This ensures both components stay in sync and eliminates the visual inconsistency.

Fixes [#1548](https://github.com/sveltejs/svelte.dev/issues/1548)

### Before
https://github.com/user-attachments/assets/03a0b451-6105-4ef6-8edd-9d9ae356cf4c


###  After
https://github.com/user-attachments/assets/75de89d5-9bc5-44c8-9489-c2227fcb4558