### PR TITLE
fix:added &amp; before &lt and &gt 

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/07-special-elements/06-svelte-element/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/07-special-elements/06-svelte-element/index.md
@@ -7,7 +7,7 @@ Sometimes you don't know in advance which element needs to be rendered. Rather t
 ```svelte
 /// file: App.svelte
 {#if selected === 'h1'}
-	<h1>I'm a <code>&lt;h1&gt;</code> element</h1>
+	<h1>I'm a <code>&amp;&lt;h1&amp;&gt;</code> element</h1>
 {:else}
 	<p>TODO others</p>
 {/if}
@@ -18,7 +18,7 @@ Sometimes you don't know in advance which element needs to be rendered. Rather t
 ```svelte
 /// file: App.svelte
 +++<svelte:element this={selected}>
-	I'm a <code>&lt;{selected}&gt;</code> element
+	I'm a <code>&amp;&lt;{selected}&amp;&gt;</code> element
 </svelte:element>+++
 ```
 


### PR DESCRIPTION
 So in tutorial it took for me a few minutes to realize that I need to use &amp;&lt; and &amp;&gt; instead of < and >. This change will show new developers the right way without guessing.

<!--
If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories.

- https://github.com/sveltejs/svelte
- https://github.com/sveltejs/kit
- https://github.com/sveltejs/cli
- https://github.com/sveltejs/ai-tools

Note that we don't accept PRs to add packages to https://svelte.dev/packages as the list is maintained by the Svelte maintainers and ambassadors
-->

### Before submitting the PR, please make sure you do the following

- [  ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [yes ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ yes] This message body should clearly illustrate what problems it solves.
