### PR TITLE
fix: Redirect old assets URL

### DIFF
--- a/apps/svelte.dev/src/hooks.server.js
+++ b/apps/svelte.dev/src/hooks.server.js
@@ -1,6 +1,8 @@
 import { redirect } from '@sveltejs/kit';
 
 const mappings = new Map([
+	// kit docs (kit.svelte.dev/docs/X → svelte.dev/docs/kit/X)
+	['/docs/kit/assets', '/docs/kit/images'],
 	// docs
 	['/docs/accessibility-warnings', '/docs/svelte/compiler-warnings'],
 	['/docs/basic-markup', '/docs/svelte/basic-markup'],


### PR DESCRIPTION
Issue: https://github.com/sveltejs/svelte.dev/issues/1935

Adds a redirect from `docs/kit/images` to `docs/kit/assets`, which accounts for earlier Reddit threads and Gemini search results referencing the legacy path.

<!--
If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories.

- https://github.com/sveltejs/svelte
- https://github.com/sveltejs/kit
- https://github.com/sveltejs/cli
- https://github.com/sveltejs/ai-tools

Note that we don't accept PRs to add packages to https://svelte.dev/packages as the list is maintained by the Svelte maintainers and ambassadors
-->

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
