### PR TITLE
fix: Fix 500 error due to undefined storage

### DIFF
--- a/packages/site-kit/src/lib/state/Persisted.svelte.ts
+++ b/packages/site-kit/src/lib/state/Persisted.svelte.ts
@@ -29,8 +29,12 @@ export class Persisted<T extends string = string> {
 		this.#subscribe(); // handle cross-tab updates
 		this.#version; // handle same-tab updates
 
-		return (this.#storage?.getItem(this.#key) as T) ?? this.#fallback;
-	}
+        try {
+            return (this.#storage?.getItem(this.#key) as T) ?? this.#fallback;
+        } catch {
+            return this.#fallback;
+        }
+}
 
 	set current(v: T) {
 		this.#storage?.setItem(this.#key, v);


### PR DESCRIPTION
Issue: https://github.com/sveltejs/svelte.dev/issues/1938

Because #storage can be undefined, calling getItem as a function throws an error.

I've wrapped it in a try...catch block to return the fallback on catch.

<!--
If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories.

- https://github.com/sveltejs/svelte
- https://github.com/sveltejs/kit
- https://github.com/sveltejs/cli
- https://github.com/sveltejs/ai-tools

Note that we don't accept PRs to add packages to https://svelte.dev/packages as the list is maintained by the Svelte maintainers and ambassadors
-->

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
