### PR TITLE
chore: update deprecated sv create() call

### DIFF
--- a/apps/svelte.dev/scripts/get_svelte_template.js
+++ b/apps/svelte.dev/scripts/get_svelte_template.js
@@ -21,7 +21,7 @@ try {
 	}
 } catch {
 	// create Svelte-Kit skelton app
-	create(output_dir, { template: 'minimal', types: 'typescript', name: 'your-app' });
+	create({ cwd: output_dir, template: 'minimal', types: 'typescript', name: 'your-app' });
 
 	function get_all_files(dir) {
 		const files = [];

--- a/apps/svelte.dev/scripts/get_svelte_template.js
+++ b/apps/svelte.dev/scripts/get_svelte_template.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { create } from 'sv';
 
-// This download the currente Vite template from Github, adjusts it to our needs, and saves it to static/svelte-template.json
+// This downloads the current Vite template from GitHub, adjusts it to our needs, and saves it to static/svelte-template.json
 // This is used by the Svelte REPL as part of the "download project" feature
 
 const force = process.env.FORCE_UPDATE === 'true';


### PR DESCRIPTION
The `get_svelte_template` script was using the deprecated `create()` form from `sv` and emitting a warning. This updates it.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
