### PR TITLE
fix: don't crash on server-side localStorage without getItem

### DIFF
--- a/packages/site-kit/src/lib/state/Persisted.svelte.ts
+++ b/packages/site-kit/src/lib/state/Persisted.svelte.ts
@@ -29,7 +29,7 @@ export class Persisted<T extends string = string> {
 		this.#subscribe(); // handle cross-tab updates
 		this.#version; // handle same-tab updates
 
-		return (this.#storage?.getItem(this.#key) as T) ?? this.#fallback;
+		return (this.#storage?.getItem?.(this.#key) as T) ?? this.#fallback;
 	}
 
 	set current(v: T) {


### PR DESCRIPTION
Fixes #1938. Alternative to #1939.

Node 25.0.0 added `localStorage` as a global (not behind an experimental flag) but its `getItem` method does not exist unless you run Node with `--localstorage-file`. This was preventing the site from running on Node 25.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
