### PR TITLE
chore: use deployment URL for prerender origin

### DIFF
--- a/apps/svelte.dev/svelte.config.js
+++ b/apps/svelte.dev/svelte.config.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import adapter from '@sveltejs/adapter-vercel';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -11,7 +12,7 @@ const config = {
 		inlineStyleThreshold: 1000,
 
 		prerender: {
-			origin: 'https://svelte.dev',
+			origin: process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'https://svelte.dev',
 
 			handleMissingId(warning) {
 				if (warning.id.startsWith('H4sIA')) {

--- a/apps/svelte.dev/svelte.config.js
+++ b/apps/svelte.dev/svelte.config.js
@@ -12,6 +12,7 @@ const config = {
 		inlineStyleThreshold: 1000,
 
 		prerender: {
+			// use deployment URL for prerender origin, so that preview environments also have the correct links
 			origin: process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'https://svelte.dev',
 
 			handleMissingId(warning) {


### PR DESCRIPTION
closes https://github.com/sveltejs/svelte.dev/issues/1446

This makes it so that our previews' relative doc links in markdown files link to the same preview docs rather than the main site which hasn't been updated yet

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
