### PR TITLE
fix: Replace "last" with "first"

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
@@ -8,7 +8,7 @@ It's easier to show why than to explain. Inside `Thing.svelte`, `name` is a dyna
 
 Click the 'Remove first thing' button a few times, and notice what happens:
 
-1. It removes the last component.
+1. It removes the first component.
 2. It then updates the `name` value in the remaining DOM nodes (the text node containing 'doughnut' now contains 'egg', and so on), but not the emoji.
 
 > [!NOTE] If you're coming from React, this might seem strange, because you're used to the entire component re-rendering when state changes. Svelte works differently: the component 'runs' once, and subsequent updates are 'fine-grained'. This makes things faster and gives you more control.


### PR DESCRIPTION
Clicking on "Remove first thing" button removes the first component not the last

### How to produce: 

1. Go to https://svelte.dev/tutorial/svelte/keyed-each-blocks
2. See the lesson description on the left
3. See the 

> Click the 'Remove first thing' button a few times, and notice what happens:
<!--
If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories.

- https://github.com/sveltejs/svelte
- https://github.com/sveltejs/kit
- https://github.com/sveltejs/cli
- https://github.com/sveltejs/ai-tools

Note that we don't accept PRs to add packages to https://svelte.dev/packages as the list is maintained by the Svelte maintainers and ambassadors
-->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
