### PR TITLE
docs: remove fixed canvas dimensions from bind:this tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/05-bind-this/+assets/app-a/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/05-bind-this/+assets/app-a/src/lib/App.svelte
@@ -15,7 +15,7 @@
 	});
 </script>
 
-<canvas width={32} height={32}></canvas>
+<canvas></canvas>
 
 <style>
 	canvas {

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/05-bind-this/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/05-bind-this/+assets/app-b/src/lib/App.svelte
@@ -17,7 +17,7 @@
 	});
 </script>
 
-<canvas bind:this={canvas} width={32} height={32}></canvas>
+<canvas bind:this={canvas}></canvas>
 
 <style>
 	canvas {

--- a/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/05-bind-this/index.md
+++ b/apps/svelte.dev/content/tutorial/02-advanced-svelte/04-advanced-bindings/05-bind-this/index.md
@@ -23,7 +23,7 @@ The `$effect` in this exercise attempts to create a canvas context, but `canvas`
 
 ```svelte
 /// file: App.svelte
-<canvas +++bind:this={canvas}+++ width={32} height={32}></canvas>
+<canvas +++bind:this={canvas}+++></canvas>
 ```
 
 Note that the value of `canvas` will remain `undefined` until the component has mounted — in other words you can't access it until the `$effect` runs.


### PR DESCRIPTION
Fixes #775.

This removes the fixed width/height attributes from the bind:this tutorial canvas examples. The visible canvas size is already controlled by CSS, and the fixed 32x32 attributes make the lesson look like it is demonstrating canvas sizing rather than focusing on bind:this.

Checks:
- Ran Prettier on the changed files
- Ran git diff --check
