### PR TITLE
chore: Supply chain hardening

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get PR ref
         if: github.event_name != 'workflow_dispatch'
         id: pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { data: pull } = await github.rest.pulls.get({
@@ -46,12 +46,12 @@ jobs:
               core.setFailed('PR is from a fork');
             }
             core.setOutput('ref', pull.head.ref);
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: github.event_name == 'workflow_dispatch' || steps.pr.outcome == 'success'
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || steps.pr.outputs.ref }}
-      - uses: pnpm/action-setup@v4.2.0
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
   #           os: ubuntu-latest
 
   #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: pnpm/action-setup@v4
-  #     - uses: actions/setup-node@v3
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+  #     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+  #     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
   #       with:
   #         node-version: ${{ matrix.node-version }}
   #         cache: pnpm
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -50,12 +50,12 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main # Explicitly checkout main branch first
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -93,7 +93,7 @@ jobs:
 
       - name: Request preview comment
         if: ${{ steps.push.outcome == 'success' }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           event-type: 'request-preview-comment'
           client-payload: |-
@@ -104,7 +104,7 @@ jobs:
 
       - name: Dispatch docs-unaffected
         if: ${{ steps.push.outcome != 'success' }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           event-type: 'docs-unaffected'
           client-payload: |-

--- a/.github/workflows/docs-preview-delete.yml
+++ b/.github/workflows/docs-preview-delete.yml
@@ -19,7 +19,7 @@ jobs:
   Sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -21,9 +21,9 @@ jobs:
   Sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -33,7 +33,7 @@ jobs:
         run: cd apps/svelte.dev && pnpm sync-docs -p "${{ inputs.repo }}#${{ inputs.repo }}#main"
 
       - name: Create or update pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           commit-message: sync ${{ inputs.repo }} docs
           title: Sync `${{ inputs.repo }}` docs

--- a/.github/workflows/sync-packages.yml
+++ b/.github/workflows/sync-packages.yml
@@ -13,11 +13,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - run: pnpm install --frozen-lockfile --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"type": "module",
 	"license": "MIT",
-	"packageManager": "pnpm@9.2.0",
+	"packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
 	"engines": {
 		"pnpm": ">=9.0.0"
 	},

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@sveltejs/*'
+  - svelte
+  - esrap
+  - devalue
+blockExoticSubdeps: true
+
 packages:
   - 'apps/*'
   - 'packages/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,13 @@
-minimumReleaseAge: 1440
+minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - '@sveltejs/*'
   - svelte
   - esrap
   - devalue
+  - zimmerframe
+  - prettier-plugin-svelte
+  - svelte-check
+  - esm-env
 blockExoticSubdeps: true
 
 packages:


### PR DESCRIPTION
`svelte.dev`

Supply-chain hardening pass.

## Changes
- Bump `packageManager` from `pnpm@9.2.0` to `pnpm@10.33.4` with `+sha512` integrity suffix.
- Add to `pnpm-workspace.yaml`:
  - `minimumReleaseAge: 1440`
  - `minimumReleaseAgeExclude: ['@sveltejs/*', svelte, esrap, devalue]`
  - `blockExoticSubdeps: true`
- In `ci.yml`, bump `actions/checkout@v3` → v6, `pnpm/action-setup@v4` → v6.0.8, `actions/setup-node@v3` → v6 (the v3 actions and the older pnpm action don't work cleanly with pnpm 10 / Node ≥18).
- Pin all third-party GitHub Actions to full SHA with `# vX.Y.Z` comments across `ci.yml`, `autofix.yml`, `docs-preview-create.yml`, `docs-preview-delete.yml`, `sync-docs.yml`, `sync-packages.yml`:
  - `actions/checkout` (v4 / v6)
  - `actions/setup-node` (v4 / v5 / v6)
  - `actions/github-script@v8`
  - `pnpm/action-setup` (v4 / v6.0.8)
  - `peter-evans/create-pull-request@v7`
  - `peter-evans/repository-dispatch@v3`