### PR TITLE
chore: fix workflow `case` condition

### DIFF
--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -38,7 +38,7 @@ permissions:
 
 env:
   BRANCH: preview-${{ inputs.upstream }}-${{ inputs.pr }}
-  REF: ${{ case(inputs.sha,  format('c/{0}', inputs.sha), format('b/{0}', inputs.branch)) }}
+  REF: ${{ case(inputs.sha == true,  format('c/{0}', inputs.sha), format('b/{0}', inputs.branch)) }}
 
 jobs:
   Sync:


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte.dev/actions/runs/26182987297 which errors because the condition in `case` is not coerced into a boolean. According to https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#literals it should if we change it to an expression?