### PR TITLE
chore: revert to resetting preview branches

### DIFF
--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -61,19 +61,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      - name: Create or update branch from main
+      - name: Create or reset branch from main
         run: |
           git fetch origin
-          if git ls-remote --exit-code --heads origin "${{ env.BRANCH }}" >/dev/null 2>&1; then
-            git checkout "${{ env.BRANCH }}"
-            if ! git merge origin/main --no-edit; then
-              git merge --abort
-              echo "Merge conflicts detected between ${{ env.BRANCH }} and origin/main. Resolve conflicts before proceeding."
-              exit 1
-            fi
-          else
-            git checkout -b "${{ env.BRANCH }}"
-          fi
+          git checkout -B ${{ env.BRANCH }} # Force create/reset branch based on current main
 
       - name: Install Svelte upstream
         if: ${{ inputs.upstream == 'svelte' }}


### PR DESCRIPTION
https://github.com/sveltejs/svelte.dev/pull/1989 was a huge flop. It's better to revert to the old behaviour of resetting for now to avoid errors such as https://github.com/sveltejs/svelte.dev/actions/runs/26241827554/job/77229920798#step:6:945