### PR TITLE
docs: note Safari tab focus behavior

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md
@@ -61,3 +61,6 @@ const off = on(node, 'keydown', handleKeydown);
 ```
 
 Now, when you open the menu, you can cycle through the options with the Tab key.
+
+> [!NOTE] In Safari, the Tab key only highlights text fields and pop-up menus by default.
+> To test this step, press <kbd>Option</kbd> + <kbd>Tab</kbd>, or enable **Press Tab to highlight each item on a webpage** in Safari's Advanced settings.


### PR DESCRIPTION
### Summary
- Adds a note to the attach tutorial for Safari users
- Mentions Option+Tab and Safari's Advanced setting for tabbing through page items

### Related issue
Fixes #971

### Testing
- prettier --check apps/svelte.dev/content/tutorial/01-svelte/08-attachments/01-attach/index.md