### PR TITLE
docs: replace `$effect` to sync state

### DIFF
--- a/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/03-link-options/01-preload/+assets/app-a/src/routes/+layout.svelte
+++ b/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/03-link-options/01-preload/+assets/app-a/src/routes/+layout.svelte
@@ -3,19 +3,20 @@
 
 	let { children } = $props();
 
-	let previous = $state();
-	let start = $state();
-	let end = $state();
-
-	$effect(() => {
+	let previousCached;
+	let startCached;
+	const { previous, start } = $derived.by(() => {
 		if (navigating.to) {
-			start = Date.now();
-			end = null;
-			previous = { ...navigating };
-		} else {
-			end = Date.now();
+			previousCached = { ...navigating };
+			startCached = Date.now();
 		}
-	});
+		return {
+			previous: previousCached,
+			start: startCached
+		}
+	})
+
+	const end = $derived(navigating.to || !start ? null : Date.now());
 </script>
 
 <nav>
@@ -26,6 +27,6 @@
 
 {@render children()}
 
-{#if previous && end}
-	<p>navigated from {previous.from.url.pathname} to {previous.to.url.pathname} in <strong>{end - start}ms</strong></p>
+{#if previous && start && end}
+  <p>navigated from {previous.from.url.pathname} to {previous.to.url.pathname} in <strong>{end - start}ms</strong></p>
 {/if}

--- a/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/03-link-options/01-preload/+assets/app-b/src/routes/+layout.svelte
+++ b/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/03-link-options/01-preload/+assets/app-b/src/routes/+layout.svelte
@@ -3,19 +3,20 @@
 
 	let { children } = $props();
 
-	let previous = $state();
-	let start = $state();
-	let end = $state();
-
-	$effect(() => {
+	let previousCached;
+	let startCached;
+	const { previous, start } = $derived.by(() => {
 		if (navigating.to) {
-			start = Date.now();
-			end = null;
-			previous = { ...navigating };
-		} else {
-			end = Date.now();
+			previousCached = { ...navigating };
+			startCached = Date.now();
 		}
-	});
+		return {
+			previous: previousCached,
+			start: startCached
+		}
+	})
+
+	const end = $derived(navigating.to || !start ? null : Date.now());
 </script>
 
 <nav>
@@ -26,6 +27,6 @@
 
 {@render children()}
 
-{#if previous && end}
-<p>navigated from {previous.from.url.pathname} to {previous.to.url.pathname} in <strong>{end - start}ms</strong></p>
+{#if previous && start && end}
+  <p>navigated from {previous.from.url.pathname} to {previous.to.url.pathname} in <strong>{end - start}ms</strong></p>
 {/if}


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte.dev/issues/1366
Closes https://github.com/sveltejs/svelte.dev/pull/1977

This PR uses `$derived` instead of `$effect`. I'm honestly not sure if this is better. On one hand, it uses Svelte fundamentals. On the other hand, https://github.com/sveltejs/svelte.dev/pull/1977 makes good use of SvelteKit lifecycle functions.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
