### PR TITLE
Fix tutorial terminal dark mode contrast

### DIFF
--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/Output.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/Output.svelte
@@ -213,14 +213,19 @@
 		font: var(--sk-font-mono);
 		padding: 1rem;
 		border-top: 1px solid var(--sk-border);
+		color: var(--sk-fg-2);
 		background: rgba(255, 255, 255, 0.5);
 		backdrop-filter: blur(3px);
 		overflow-y: auto;
 	}
 
 	@media (prefers-color-scheme: dark) {
-		.terminal {
-			background: rgba(0, 0, 0, 0.1);
+		:global(:root:not(.light)) .terminal {
+			background: var(--sk-bg-1);
 		}
+	}
+
+	:global(:root.dark) .terminal {
+		background: var(--sk-bg-1);
 	}
 </style>

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
@@ -92,14 +92,9 @@
 		width: 100%;
 		height: 100%;
 		font: var(--sk-font-mono);
+		color: var(--sk-fg-2);
 		background: var(--sk-bg-1);
 		border-top: 1px solid var(--sk-border);
 		overflow-y: auto;
-	}
-
-	@media (prefers-color-scheme: dark) {
-		.terminal {
-			background: rgba(0, 0, 0, 0.5);
-		}
 	}
 </style>


### PR DESCRIPTION
## Problem

The tutorial terminal used very transparent dark-mode backgrounds. In the SvelteKit tutorial this could leave log text sitting on a low-contrast surface in dark mode.

## Approach

- Keep the light-mode translucent terminal treatment.
- In dark mode, use the site theme background token for the terminal panel instead of a nearly transparent black overlay.
- Apply the same readable foreground token to both WebContainer and Rollup tutorial terminal variants.
- Support both system dark mode and the explicit `:root.dark` theme toggle.

## Security

CSS-only change. No runtime logic, dependency, auth, storage, or network behavior changes.

## Verification

- `corepack pnpm --filter svelte.dev check` -> `svelte-check found 0 errors and 0 warnings`
- `corepack pnpm --dir apps/svelte.dev exec prettier --check src/routes/tutorial/[...slug]/Output.svelte src/routes/tutorial/[...slug]/OutputRollup.svelte` -> passed
- `git diff --check` -> passed

Note: `corepack pnpm --filter svelte.dev lint` currently reports formatting warnings across many pre-existing files outside this PR. The two changed files pass targeted Prettier check.

Fixes #2004