### PR TITLE
fix: improve tutorial terminal text contast in dark mode

### DIFF
--- a/apps/svelte.dev/src/lib/tutorial/adapters/webcontainer/index.svelte.ts
+++ b/apps/svelte.dev/src/lib/tutorial/adapters/webcontainer/index.svelte.ts
@@ -10,7 +10,15 @@ import type { Adapter } from '$lib/tutorial';
 import type { Item, File } from '@sveltejs/repl/workspace';
 
 const converter = new AnsiToHtml({
-	fg: 'var(--sk-fg-3)'
+	fg: 'var(--sk-fg-3)',
+	// override the default colours so that they have better contrast in dark mode
+	colors: {
+		// new vs original colour
+		1: '#e06060', // #A00
+		3: '#c47a20', // #A50
+		4: '#4d9eff', // #00A
+		8: '#7a7a7a' // #555
+	}
 });
 
 /** Web container singleton */

--- a/apps/svelte.dev/src/lib/tutorial/adapters/webcontainer/index.svelte.ts
+++ b/apps/svelte.dev/src/lib/tutorial/adapters/webcontainer/index.svelte.ts
@@ -17,6 +17,7 @@ const converter = new AnsiToHtml({
 		1: '#e06060', // #A00
 		3: '#c47a20', // #A50
 		4: '#4d9eff', // #00A
+		5: '#c060c0', // #A0A
 		8: '#7a7a7a' // #555
 	}
 });

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/Output.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/Output.svelte
@@ -213,14 +213,7 @@
 		font: var(--sk-font-mono);
 		padding: 1rem;
 		border-top: 1px solid var(--sk-border);
-		background: rgba(255, 255, 255, 0.5);
 		backdrop-filter: blur(3px);
 		overflow-y: auto;
-	}
-
-	@media (prefers-color-scheme: dark) {
-		.terminal {
-			background: rgba(0, 0, 0, 0.1);
-		}
 	}
 </style>

--- a/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
+++ b/apps/svelte.dev/src/routes/tutorial/[...slug]/OutputRollup.svelte
@@ -96,10 +96,4 @@
 		border-top: 1px solid var(--sk-border);
 		overflow-y: auto;
 	}
-
-	@media (prefers-color-scheme: dark) {
-		.terminal {
-			background: rgba(0, 0, 0, 0.5);
-		}
-	}
 </style>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte.dev/issues/2004

Overrides the `ansi-to-html` colours so that they're more readable in dark mode while maintaining readability in light mode and fixes the dark mode terminal background

Old:
<img width="1390" height="968" alt="old dark mode terminal" src="https://github.com/user-attachments/assets/35378a04-8814-47b2-8d88-e5275e668c02" />

New:
<img width="1392" height="494" alt="new dark mode terminal" src="https://github.com/user-attachments/assets/5d168f5f-ea51-44be-8e56-0607fdace14d" />

