### PR TITLE
fix: cap effects tutorial interval delay

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/05-effects/+assets/app-b/src/lib/App.svelte
+++ b/apps/svelte.dev/content/tutorial/01-svelte/02-reactivity/05-effects/+assets/app-b/src/lib/App.svelte
@@ -1,6 +1,7 @@
 <script>
 	let elapsed = $state(0);
 	let interval = $state(1000);
+	const MAX_INTERVAL = 2 ** 31 - 1;
 
 	$effect(() => {
 		const id = setInterval(() => {
@@ -14,6 +15,6 @@
 </script>
 
 <button onclick={() => interval /= 2}>speed up</button>
-<button onclick={() => interval *= 2}>slow down</button>
+<button onclick={() => interval = Math.min(interval * 2, MAX_INTERVAL)}>slow down</button>
 
 <p>elapsed: {elapsed}</p>


### PR DESCRIPTION
﻿## Summary
- cap the effects tutorial solution interval at the maximum 32-bit timer delay
- prevent repeated "slow down" clicks from overflowing the browser timer delay and making the counter tick quickly again

Closes #1954

## Validation
- `corepack pnpm exec prettier --write content/tutorial/01-svelte/02-reactivity/05-effects/+assets/app-b/src/lib/App.svelte`
- `corepack pnpm exec prettier --check content/tutorial/01-svelte/02-reactivity/05-effects/+assets/app-b/src/lib/App.svelte`
- `git diff --check`

Note: `corepack pnpm --filter svelte.dev lint` still reports pre-existing formatting warnings across many unrelated files; the changed tutorial file passes the targeted Prettier check.
