### PR TITLE
design: tweak tables

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -513,7 +513,12 @@
 		}
 
 		table {
+			border-collapse: collapse;
 			margin: 1em 0;
+
+			th {
+				font: var(--sk-font-h3);
+			}
 		}
 
 		small {

--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -518,6 +518,7 @@
 
 			th {
 				font: var(--sk-font-h3);
+				font-size: var(--sk-font-size-body);
 			}
 		}
 


### PR DESCRIPTION
Table headers are currently breaking one of our typographical rules, which is to never bold `--sk-font-body`. Headers should use header type; this fixes it.

It also fixes the subtle-but-once-seen-can't-be-unseen border gap