### PR TITLE
fix: update write-less-code repl version from 3 to 5

### DIFF
--- a/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md
+++ b/apps/svelte.dev/content/blog/2019-04-20-write-less-code.md
@@ -40,7 +40,7 @@ Reducing the amount of code you have to write is an explicit goal of Svelte. To 
 <div class="max">
 	<iframe
 		title="Simple component example"
-		src="/repl/blog-write-less-code/embed?version=3"
+		src="/repl/blog-write-less-code/embed?version=5"
 		scrolling="no"
 	></iframe>
 </div>


### PR DESCRIPTION
Fixes #1968.

The "write-less-code" blog post embeds a REPL that was migrated to Svelte 5 syntax (using `$state`) in #294, but the iframe's `?version=3` query parameter was not updated, causing the embedded REPL to load Svelte 3 — which doesn't understand `$state` and breaks the snippet.

This changes the version from `3` to `5` so the embedded REPL uses Svelte 5 to compile the example.