### PR TITLE
docs: use `false` instead of `'off'` in tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/03-link-options/01-preload/index.md
+++ b/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/03-link-options/01-preload/index.md
@@ -29,7 +29,7 @@ You can customise the behaviour further by specifying one of the following value
 
 - `"hover"` (default, falls back to `"tap"` on mobile)
 - `"tap"` — only begin preloading on tap
-- `"off"` — disable preloading
+- `"false"` — disable preloading
 
 Using `data-sveltekit-preload-data` may sometimes result in false positives - i.e. loading data in anticipation of a navigation that doesn't then happen — which might be undesirable. As an alternative, `data-sveltekit-preload-code` allows you to preload the JavaScript needed by a given route without eagerly loading its data. This attribute can have the following values:
 
@@ -37,7 +37,7 @@ Using `data-sveltekit-preload-data` may sometimes result in false positives - i
 - `"viewport"` — preload everything as it appears in the viewport
 - `"hover"` (default) as above
 - `"tap"` — as above
-- `"off"` — as above
+- `"false"` — as above
 
 You can also initiate preloading programmatically with `preloadCode` and `preloadData` imported from `$app/navigation`:
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/13597

We have removed `'off'` in https://github.com/sveltejs/kit/pull/15907 so the preferred value is `false`

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
