### PR TITLE
chore: add `"type": "module"` to `package.json`

### DIFF
--- a/packages/gzip/package.json
+++ b/packages/gzip/package.json
@@ -2,6 +2,7 @@
 	"name": "gzip",
 	"version": "1.0.0",
 	"private": true,
+	"type": "module",
 	"exports": {
 		".": "./index.js"
 	}


### PR DESCRIPTION
Gets rid of the following warning when syncing the docs:
```
Run cd apps/svelte.dev && pnpm sync-docs --owner="sveltejs" -p "kit#kit#changeset-release/version-3"

> svelte.dev@1.0.0 sync-docs /home/runner/work/svelte.dev/svelte.dev/apps/svelte.dev
> node scripts/sync-docs/index.ts --owner=sveltejs -p 'kit#kit#changeset-release/version-3'

(node:2501) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///home/runner/work/svelte.dev/svelte.dev/packages/gzip/index.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /home/runner/work/svelte.dev/svelte.dev/packages/gzip/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
```