### PR TITLE
fix: use new `$app/env` links instead of `$app/environment`

### DIFF
--- a/apps/svelte.dev/src/routes/docs/kit/modules/+page.svelte
+++ b/apps/svelte.dev/src/routes/docs/kit/modules/+page.svelte
@@ -2,10 +2,10 @@
 	import RemovedPage from '../../RemovedPage.svelte';
 
 	const docs = new Map([
-		['$app-environment-browser', ['`$app/env#browser`', '/docs/kit/$app-environment#browser']],
-		['$app-environment-building', ['`$app/env#building`', '/docs/kit/$app-environment#building']],
-		['$app-environment-dev', ['`$app/env#dev`', '/docs/kit/$app-environment#dev']],
-		['$app-environment-version', ['`$app/env#version`', '/docs/kit/$app-environment#version']],
+		['$app-environment-browser', ['`$app/env#browser`', '/docs/kit/$app-env#browser']],
+		['$app-environment-building', ['`$app/env#building`', '/docs/kit/$app-env#building']],
+		['$app-environment-dev', ['`$app/env#dev`', '/docs/kit/$app-env#dev']],
+		['$app-environment-version', ['`$app/env#version`', '/docs/kit/$app-env#version']],
 		['$app-forms-applyaction', ['`$app/forms#applyAction`', '/docs/kit/$app-forms#applyAction']],
 		['$app-forms-deserialize', ['`$app/forms#deserialize`', '/docs/kit/$app-forms#deserialize']],
 		['$app-forms-enhance', ['`$app/forms#enhance`', '/docs/kit/$app-forms#enhance']],


### PR DESCRIPTION
Prerequisite to merging https://github.com/sveltejs/kit/pull/15975 otherwise preview deployments fail because those pages don't exist anymore in the `version-3` branch. It's probably fine to link there too now since they already have a note about the difference between the two modules in the v2 docs