### PR TITLE
fix: ensure app still builds when SvelteKit 2 previews are deployed

### DIFF
--- a/apps/svelte.dev/vite.config.ts
+++ b/apps/svelte.dev/vite.config.ts
@@ -4,6 +4,7 @@ import adapter from '@sveltejs/adapter-vercel';
 import type { PluginOption, UserConfig } from 'vite';
 import { browserslistToTargets } from 'lightningcss';
 import browserslist from 'browserslist';
+import { VERSION } from '@sveltejs/kit';
 
 const plugins: PluginOption[] = [
 	enhancedImages(),
@@ -49,7 +50,16 @@ const plugins: PluginOption[] = [
 
 				throw new Error(warning.message);
 			}
-		}
+		},
+
+		// TODO: remove this when we stop deploying previews for Kit 2
+		experimental:
+			VERSION[0] === '2'
+				? {
+						// @ts-expect-error this is invalid in Kit 3 but valid in Kit 2
+						explicitEnvironmentVariables: true
+					}
+				: undefined
 	}) as PluginOption
 ];
 


### PR DESCRIPTION
This PR adds a check for the installed Kit version and conditionally enables the experimental env option. This ensures that the app builds on PRs that deploy a SvelteKit 2 version where explicit env is not the default yet. Otherwise, the deployments fail on SvelteKit PRs against `main`