### PR TITLE
chore: add sonda to package registry

### DIFF
--- a/apps/svelte.dev/src/lib/packages-meta.ts
+++ b/apps/svelte.dev/src/lib/packages-meta.ts
@@ -312,7 +312,8 @@ const FEATURED: {
 		title: 'Devtools',
 		packages: [
 			{ name: 'svelte-render-scan', description: 'Visual debugging tool' },
-			{ name: 'svelte-inspect-value', description: 'Value inspector component' }
+			{ name: 'svelte-inspect-value', description: 'Value inspector component' },
+			{ name: 'sonda', description: 'Universal bundle analyzer and visualizer' }
 		]
 	},
 	{

--- a/apps/svelte.dev/src/lib/server/generated/registry/sonda.json
+++ b/apps/svelte.dev/src/lib/server/generated/registry/sonda.json
@@ -1,0 +1,13 @@
+{
+  "name": "sonda",
+  "npm_description": "Universal bundle analyzer and visualizer that works with most popular bundlers and frameworks.",
+  "repo_url": "https://github.com/filipsobol/sonda",
+  "authors": [
+    "filipsobol"
+  ],
+  "homepage": "https://sonda.dev",
+  "version": "0.12.0",
+  "downloads": 144036,
+  "github_stars": 772,
+  "updated": "2026-06-07T13:48:13.798Z"
+}


### PR DESCRIPTION
This PR adds Sonda to the Devtools section on `/packages`.

Sonda is a bundle analyzer that helps inspect build outputs. It works with several bundlers and frameworks, including SvelteKit via its SvelteKit integration: https://sonda.dev/frameworks/sveltekit.html

Website: https://sonda.dev/
npmx: https://npmx.dev/package/sonda