### PR TITLE
chore: update doc syncing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ The tutorial, blog and examples are maintained within this repository.
 ```
 pnpm install
 cd apps/svelte.dev
-pnpm sync-docs -p # the -p flag clones our git repos. Otherwise, it expects symlinked local repositories in `apps/svelte.dev/repos`
+pnpm sync-docs -p # use the -p flag to clone the git repos into `apps/svelte.dev/repos`
 pnpm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ The tutorial, blog and examples are maintained within this repository.
 ```
 pnpm install
 cd apps/svelte.dev
-USE_GIT=true pnpm sync-docs
+pnpm sync-docs -p # the -p flag clones our git repos. Otherwise, it expects symlinked local repositories in `apps/svelte.dev/repos`
 pnpm run dev
 ```

--- a/apps/svelte.dev/scripts/sync-docs/index.ts
+++ b/apps/svelte.dev/scripts/sync-docs/index.ts
@@ -200,8 +200,8 @@ const packages: Package[] = [
 		docs: 'documentation/docs',
 		types: null,
 		post_clone: async (dir) => {
-			await invoke('npx', ['pnpm@10', 'install'], { cwd: dir });
-			await invoke('npx', ['pnpm@10', 'build'], { cwd: dir });
+			await invoke('pnpm', ['install'], { cwd: dir });
+			await invoke('pnpm', ['build'], { cwd: dir });
 			patch_node_modules(dir, 'packages/sv', 'sv');
 			patch_node_modules(dir, 'packages/sv-utils', '@sveltejs/sv-utils');
 		}


### PR DESCRIPTION
This PR updates the README.md which is outdated. There is no `USE_GIT=true` expected by the script. It was changed to a `-p` flag in https://github.com/sveltejs/svelte.dev/pull/726/changes#diff-d43c2f277b0456401e6842dae4c092978af72182e078e47bf99e4f9bc74e57abL127