### PR TITLE
docs: Fix create -> delete in index.md

### DIFF
--- a/apps/svelte.dev/content/tutorial/03-sveltekit/06-forms/02-named-form-actions/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/06-forms/02-named-form-actions/index.md
@@ -40,7 +40,7 @@ The `<form>` element has an optional `action` attribute, which is similar to an 
 
 > [!NOTE] The `action` attribute can be any URL — if the action was defined on another page, you might have something like `/todos?/create`. Since the action is on _this_ page, we can omit the pathname altogether, hence the leading `?` character.
 
-Next, we want to create a form for each todo, complete with a hidden `<input>` that uniquely identifies it:
+Next, we want to delete a form for each todo, complete with a hidden `<input>` that uniquely identifies it:
 
 ```svelte
 /// file: src/routes/+page.svelte


### PR DESCRIPTION
`Next, we want to create a form for each todo, complete with a hidden <input> that uniquely identifies it:`  -> We are going to delete instead of creating.

<!--
If this is a documentation PR (i.e. changing content within `apps/svelte.dev/content/docs`), then this is the wrong repository to make those changes. The content in this folder is synced from other repositories. Therefore, these changes should be made in their respective repositories.

- https://github.com/sveltejs/svelte
- https://github.com/sveltejs/kit
- https://github.com/sveltejs/cli
- https://github.com/sveltejs/ai-tools

Note that we don't accept PRs to add packages to https://svelte.dev/packages as the list is maintained by the Svelte maintainers and ambassadors
-->

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
