### PR TITLE
chore: use correct secret name in preview delete workflow

### DIFF
--- a/.github/workflows/docs-preview-delete.yml
+++ b/.github/workflows/docs-preview-delete.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete branch
         run: git push origin :${{ env.BRANCH }}


### PR DESCRIPTION
This PR changes the GitHub token secret name used in the preview delete workflow to the same one in the preview create workflow. Probably explains why all our deletes have been erroring https://github.com/sveltejs/svelte.dev/actions/runs/28447056974/job/84299076375#step:2:19