### PR TITLE
chore: add permission to delete preview branches

### DIFF
--- a/.github/workflows/docs-preview-delete.yml
+++ b/.github/workflows/docs-preview-delete.yml
@@ -16,6 +16,9 @@ on:
 env:
   BRANCH: preview-${{ inputs.repo }}-${{ inputs.pr }}
 
+permissions:
+  contents: write
+
 jobs:
   Sync:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-Run `pnpm prettier --write` on any files you change.
+Run `pnpx prettier --write` on any files you change.


### PR DESCRIPTION
Adds the `contents: write` permission for the preview branch clean up workflow to avoid these errors https://github.com/sveltejs/svelte.dev/actions/runs/28449714847/job/84308355483#step:3:7