### PR TITLE
fix: prevent 404 on llms.txt links after client-side navigation

### DIFF
--- a/apps/svelte.dev/src/lib/components/PageControls.svelte
+++ b/apps/svelte.dev/src/lib/components/PageControls.svelte
@@ -23,7 +23,7 @@
 		<Icon name="edit" /> Edit this page on GitHub
 	</a>
 	{#if llms}
-		<a href={page.url.pathname.replace(/\/$/, '') + '/llms.txt'}>
+		<a data-sveltekit-reload href={page.url.pathname.replace(/\/$/, '') + '/llms.txt'}>
 			<Icon name="contents" /> llms.txt
 		</a>
 	{/if}

--- a/apps/svelte.dev/src/routes/docs/llms/+page.svelte
+++ b/apps/svelte.dev/src/routes/docs/llms/+page.svelte
@@ -13,7 +13,7 @@
 
 		<p>Currently, we have the following root-level files...</p>
 
-		<ul>
+		<ul data-sveltekit-reload>
 			<li><a href="/llms.txt">/llms.txt</a> — a listing of the available files</li>
 			<li>
 				<a href="/llms-full.txt">/llms-full.txt</a> — complete documentation for Svelte, SvelteKit and
@@ -31,7 +31,7 @@
 
 		<p>...and package-level documentation:</p>
 
-		<ul>
+		<ul data-sveltekit-reload>
 			<li>
 				<a href="/docs/svelte/llms.txt">/docs/svelte/llms.txt</a> /
 				<a href="/docs/svelte/llms-small.txt">/docs/svelte/llms-small.txt</a>


### PR DESCRIPTION
## Summary
- The `llms.txt` link at the bottom of doc pages (and on `/docs/llms`) points to a route that only has a `+server.ts` (no `+page.svelte`). SvelteKit's client-side router intercepted the click and tried to render it as an SPA page, which fails since there's no page component — resulting in a client-rendered 404. A hard reload bypasses the client router entirely and hits the server route directly, which works correctly.
- Add `data-sveltekit-reload` to these links so they always perform a full browser navigation instead of being intercepted by the SPA router.

## Test plan
- [ ] Visit a docs page (e.g. `/docs/kit/adapter-cloudflare#Usage`) and click the `llms.txt` link at the bottom, confirm it loads the file instead of a 404.
- [ ] Visit `/docs/llms` and click each of the listed `llms*.txt` links, confirm they all load correctly.
