### PR TITLE
feat: add markstream-svelte to Svelte packages

### DIFF
--- a/apps/svelte.dev/src/lib/packages-meta.ts
+++ b/apps/svelte.dev/src/lib/packages-meta.ts
@@ -124,6 +124,10 @@ const FEATURED: {
 				name: '@content-collections/core',
 				description: 'Transform your content into type-safe data collections'
 			},
+			{
+				name: 'markstream-svelte',
+				description: 'Svelte 5 streaming Markdown renderer for AI chat interfaces'
+			},
 			{ name: 'svelte-exmarkdown', description: 'Extensible component for Markdown rendering' },
 			{
 				name: '@magidoc/plugin-svelte-marked',


### PR DESCRIPTION
## Summary

- add `markstream-svelte` to the Content section of the Svelte packages page
- describe its Svelte 5 streaming Markdown renderer for AI chat interfaces

## Notes

- npm: https://www.npmjs.com/package/markstream-svelte
- source: https://github.com/Simon-He95/markstream-vue
- docs: https://markstream.simonhe.me/frameworks/svelte

The package is MIT-licensed and declares `svelte >=5 <6` as a peer dependency. This is a focused metadata-only change.