### PR TITLE
feat: add svedit to Svelte packages

### DIFF
--- a/apps/svelte.dev/src/lib/packages-meta.ts
+++ b/apps/svelte.dev/src/lib/packages-meta.ts
@@ -150,6 +150,7 @@ const FEATURED: {
 	{
 		title: 'Rich text editing',
 		packages: [
+			{ name: 'svedit', description: 'Editing for Svelte' },
 			{ name: 'prosekit', description: 'Framework agnostic and headless rich text editor' },
 			{ name: 'svelte-lexical', description: 'Rich text editor for Svelte based on lexical' },
 			{ name: 'typewriter-editor' }


### PR DESCRIPTION
Add `svedit` to the Svelte packages page under "Rich text editing".

See:
- npmx: https://npmx.dev/package/svedit
- source+docs: https://github.com/michael/svedit
- demo: https://svedit.dev
- license: MIT

If `description` should be more descriptive: "Structured, full-canvas editing for Svelte" would be another candiate.

