### PR TITLE
chore: remove runtime config

### DIFF
--- a/apps/svelte.dev/src/routes/(authed)/+layout.server.js
+++ b/apps/svelte.dev/src/routes/(authed)/+layout.server.js
@@ -2,11 +2,6 @@ import * as session from '#lib/db/session';
 
 export const prerender = false;
 
-/** @type {import('@sveltejs/adapter-vercel').Config} */
-export const config = {
-	runtime: 'nodejs20.x' // see https://github.com/sveltejs/svelte/pull/9136
-};
-
 export async function load({ request }) {
 	return {
 		user: await session.from_cookie(request.headers.get('cookie'))


### PR DESCRIPTION
SvelteKit 3 does not support Node 20 — we can just use the project's default Node version in the Vercel build container, which as of a few seconds ago changed from 22 to 24