### PR TITLE
docs: clarify when the updated-state toast appears

### DIFF
--- a/apps/svelte.dev/content/tutorial/03-sveltekit/08-app-state/03-updated-state/index.md
+++ b/apps/svelte.dev/content/tutorial/03-sveltekit/08-app-state/03-updated-state/index.md
@@ -4,6 +4,8 @@ title: updated
 
 The `updated` state contains `true` or `false` depending on whether a new version of the app has been deployed since the page was first opened. For this to work, your `svelte.config.js` must specify `kit.version.pollInterval`.
 
+The toast only appears after the app detects a version change, so load the page, deploy a new version, and wait for the next poll.
+
 ```svelte
 /// file: src/routes/+layout.svelte
 <script>


### PR DESCRIPTION
## Summary

Clarifies that the updated-state toast appears only after SvelteKit detects a newly deployed app version. The added guidance tells readers to load the page, deploy a new version, and wait for the next configured poll.

## Validation

- `git diff --check`

Fixes #787
