### PR TITLE
docs: Several tutorial pages loading in light mode sometimes instead of (my system preferred) dark mode when performing 

### DIFF
--- a/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/+assets/app-a/src/routes/login/+page.svelte
+++ b/apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/+assets/app-a/src/routes/login/+page.svelte
@@ -1,5 +1,9 @@
+<script>
+	import { enhance } from '$app/forms';
+</script>
+
 <h1>log in</h1>
 
-<form method="POST">
+<form method="POST" use:enhance>
 	<button>log in</button>
 </form>


### PR DESCRIPTION
## Summary

Addresses #1111: Several tutorial pages loading in light mode sometimes instead of (my system preferred) dark mode when performing actions

## Changed files

- `apps/svelte.dev/content/tutorial/04-advanced-sveltekit/04-advanced-routing/04-route-groups/+assets/app-a/src/routes/login/+page.svelte`

## Validation

- `git diff --check`: passed

Fixes #1111
