### PR TITLE
chore: add npm `prepare` script

### DIFF
--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -13,6 +13,7 @@
 		"check": "node scripts/update.js && svelte-kit sync && svelte-check",
 		"format": "prettier --write .",
 		"lint": "prettier --check .",
+		"prepare": "svelte-kit sync",
 		"sync-docs": "node scripts/sync-docs/index.ts",
 		"sync-packages": "node scripts/sync-packages/index.ts"
 	},

--- a/packages/site-kit/package.json
+++ b/packages/site-kit/package.json
@@ -8,7 +8,8 @@
 		"check": "svelte-kit sync && svelte-check",
 		"package": "svelte-kit sync",
 		"lint": "prettier --check .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"prepare": "svelte-kit sync"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This makes the dev experience a bit better, otherwise oxc errors because it can't find the `$app/types` tsconfig after running `pnpm dev`