### PR TITLE
feat: add svelte-adapter-nitro to packages

### DIFF
--- a/apps/svelte.dev/src/lib/packages-meta.ts
+++ b/apps/svelte.dev/src/lib/packages-meta.ts
@@ -99,6 +99,7 @@ const FEATURED: {
 			{ name: 'amplify-adapter', description: 'Builds your app for AWS Amplify' },
 			{ name: 'svelte-kit-sst', description: 'Builds your app for AWS Lambda and AWS Lamda@Edge' },
 			{ name: 'svelte-adapter-bun', description: 'Builds your app for Bun' },
+			{ name: 'svelte-adapter-nitro', description: 'Builds your app with Nitro' },
 			{
 				name: 'svelte-adapter-appengine',
 				description: 'Builds your app for Google Cloud App Engine'


### PR DESCRIPTION
## Summary

- add `svelte-adapter-nitro` to the SvelteKit adapters section of the packages page
- describe it as a Nitro-powered build adapter so users can identify its purpose at a glance

This makes the community adapter discoverable alongside the existing Node, platform, and runtime adapters.

## Verification

- `pnpm --filter svelte.dev check` — 0 errors and 0 warnings
- `pnpx prettier --write apps/svelte.dev/src/lib/packages-meta.ts` — unchanged