### PR TITLE
chore: remove degit

### DIFF
--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -62,7 +62,6 @@
 		"@types/node": "catalog:",
 		"browserslist": "^4.28.1",
 		"chokidar": "^5.0.0",
-		"degit": "^2.8.4",
 		"esbuild": "^0.27.3",
 		"gzip": "workspace:*",
 		"jimp": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,9 +155,6 @@ importers:
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
-      degit:
-        specifier: ^2.8.4
-        version: 2.8.4
       esbuild:
         specifier: ^0.27.3
         version: 0.27.7
@@ -2127,11 +2124,6 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-
-  degit@2.8.4:
-    resolution: {integrity: sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -4699,8 +4691,6 @@ snapshots:
   dedent-js@1.0.1: {}
 
   deepmerge@4.3.1: {}
-
-  degit@2.8.4: {}
 
   dequal@2.0.3: {}
 


### PR DESCRIPTION
I don't think this is used anymore? I can't see what it's used for, anyway. This would address https://github.com/sveltejs/svelte.dev/security/dependabot/169 by removing the dependency completely.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
