### PR TITLE
fix: remove unused `vite-imagetools` code

### DIFF
--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -81,7 +81,6 @@
 		"typescript": "^6.0.3",
 		"valibot": "^1.2.0",
 		"vite": "catalog:",
-		"vite-imagetools": "^9.0.3",
 		"vitest": "catalog:"
 	},
 	"imports": {

--- a/apps/svelte.dev/src/env.d.ts
+++ b/apps/svelte.dev/src/env.d.ts
@@ -6,8 +6,3 @@ interface ImageToolsPictureData {
 		h: number;
 	};
 }
-
-declare module '*?big-image' {
-	const value: ImageToolsPictureData;
-	export default value;
-}

--- a/apps/svelte.dev/vite.config.ts
+++ b/apps/svelte.dev/vite.config.ts
@@ -79,22 +79,6 @@ const plugins: PluginOption[] = [
 	}) as PluginOption
 ];
 
-// Only enable sharp if we're not in a webcontainer env
-if (!process.versions.webcontainer) {
-	plugins.push(
-		(await import('vite-imagetools')).imagetools({
-			exclude: 'content/**',
-			defaultDirectives: (url) => {
-				if (url.searchParams.has('big-image')) {
-					return new URLSearchParams('w=640;1280;2560;3840&format=avif;webp;png&as=picture');
-				}
-
-				return new URLSearchParams();
-			}
-		}) as PluginOption
-	);
-}
-
 const config: UserConfig = {
 	plugins,
 	css: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,9 +212,6 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)
-      vite-imagetools:
-        specifier: ^9.0.3
-        version: 9.0.3(rollup@4.59.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@22.19.20)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))


### PR DESCRIPTION
I can't find any pictures with the `?big-image` query parameter so this should be safe to remove. It was introduced in the initial commit for the repo but even in that one I couldn't find any references to it. Also fixes version-3 preview docs