### PR TITLE
prevent preview deployments from `next`

### DIFF
--- a/apps/svelte.dev/vercel.json
+++ b/apps/svelte.dev/vercel.json
@@ -41,5 +41,10 @@
 				}
 			]
 		}
-	]
+	],
+	"git": {
+		"deploymentEnabled": {
+			"next": "false"
+		}
+	}
 }

--- a/apps/svelte.dev/vercel.json
+++ b/apps/svelte.dev/vercel.json
@@ -44,7 +44,7 @@
 	],
 	"git": {
 		"deploymentEnabled": {
-			"next": "false"
+			"next": false
 		}
 	}
 }


### PR DESCRIPTION
this should prevent errors like this one:

<img width="517" height="168" alt="image" src="https://github.com/user-attachments/assets/5aca2e03-36d5-428b-a111-279568dccd9b" />

