### PR TITLE
chore: disable twoslash cache

### DIFF
--- a/apps/svelte.dev/vite.config.ts
+++ b/apps/svelte.dev/vite.config.ts
@@ -50,6 +50,10 @@ const plugins: PluginOption[] = [
 				: undefined,
 
 		prerender: {
+			handleHttpError({ referrer, referenceType, message }) {
+				// TODO: we need a better default in SvelteKit, otherwise the error message is too ambiguous
+				throw new Error(`${message} when ${referenceType} by ${referrer}`);
+			},
 			handleMissingId(warning) {
 				if (warning.id.startsWith('H4sIA')) {
 					// playground link — do nothing

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -1163,7 +1163,7 @@ async function syntax_highlight({
 									}
 								},
 								// by default, twoslash does not run on .js files, change that through this option
-								filter: () => true,
+								filter: () => true
 								// TODO: re-enable type hover cache when we find out how to invalidate
 								// it when the types have changed
 								// typesCache: createFileSystemTypesCache({

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -9,7 +9,7 @@ import { createHighlighterCore } from 'shiki/core';
 import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 import { createCssVariablesTheme } from 'shiki';
 import { transformerTwoslash, rendererRich } from '@shikijs/twoslash';
-import { createFileSystemTypesCache } from '@shikijs/vitepress-twoslash/cache-fs';
+// import { createFileSystemTypesCache } from '@shikijs/vitepress-twoslash/cache-fs';
 import { compress_and_encode_text } from 'gzip';
 import {
 	decode_html_entities,
@@ -1164,9 +1164,11 @@ async function syntax_highlight({
 								},
 								// by default, twoslash does not run on .js files, change that through this option
 								filter: () => true,
-								typesCache: createFileSystemTypesCache({
-									dir: 'node_modules/.cache/twoslash'
-								})
+								// TODO: re-enable type hover cache when we find out how to invalidate
+								// it when the types have changed
+								// typesCache: createFileSystemTypesCache({
+								// 	dir: 'node_modules/.cache/twoslash'
+								// })
 							})
 						]
 					: []


### PR DESCRIPTION
Caching is hard. There's also a bug where twoslash is creating type hover of the codeblocks inside type hovers and that can contain stale references to non-existent links. For some reason, _that_ isn't invalidated when deleting the cache directory (I can't be bothered to look into that now but it could also explain why twoslash is so slow)