### PR TITLE
chore: use `next` branch as base for kit previews

### DIFF
--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -53,7 +53,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: main # Explicitly checkout main branch first
+          # TODO: revert this to 'main' when we merge kit next docs
+          ref: ${{ inputs.upstream == 'kit' && 'next' || 'main' }} # Explicitly checkout main branch first
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
This should help us catch errors earlier