### PR TITLE
fix: use a separate package for types resolution

### DIFF
--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -82,15 +82,15 @@ jobs:
 
       - name: Install Svelte upstream
         if: ${{ inputs.upstream == 'svelte' }}
-        run: pnpm add https://pkg.svelte.dev/svelte/${{ steps.resolve.outputs.ref }} --filter "@sveltejs/docs-types"
+        run: pnpm add https://pkg.svelte.dev/svelte/${{ steps.resolve.outputs.ref }} --filter "docs-types"
 
       - name: Install SvelteKit upstream
         if: ${{ inputs.upstream == 'kit' }}
-        run: pnpm add https://pkg.svelte.dev/@sveltejs/kit/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/adapter-vercel/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/enhanced-img/${{ steps.resolve.outputs.ref }} --filter "@sveltejs/docs-types"
+        run: pnpm add https://pkg.svelte.dev/@sveltejs/kit/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/adapter-vercel/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/enhanced-img/${{ steps.resolve.outputs.ref }} --filter "docs-types"
 
       - name: Install Svelte CLI upstream
         if: ${{ inputs.upstream == 'cli' }}
-        run: pnpm add https://pkg.svelte.dev/sv/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/sv-utils/${{ steps.resolve.outputs.ref }} --filter "@sveltejs/docs-types"
+        run: pnpm add https://pkg.svelte.dev/sv/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/sv-utils/${{ steps.resolve.outputs.ref }} --filter "docs-types"
 
       - name: Sync
         run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ inputs.owner }}" -p "${{ format('{0}#{1}#{2}', inputs.upstream, inputs.downstream, inputs.branch) }}"

--- a/.github/workflows/docs-preview-create.yml
+++ b/.github/workflows/docs-preview-create.yml
@@ -82,15 +82,15 @@ jobs:
 
       - name: Install Svelte upstream
         if: ${{ inputs.upstream == 'svelte' }}
-        run: pnpm add -D https://pkg.svelte.dev/svelte/${{ steps.resolve.outputs.ref }} --filter "svelte.dev"
+        run: pnpm add https://pkg.svelte.dev/svelte/${{ steps.resolve.outputs.ref }} --filter "@sveltejs/docs-types"
 
       - name: Install SvelteKit upstream
         if: ${{ inputs.upstream == 'kit' }}
-        run: pnpm add -D https://pkg.svelte.dev/@sveltejs/kit/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/adapter-vercel/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/enhanced-img/${{ steps.resolve.outputs.ref }} --filter "svelte.dev"
+        run: pnpm add https://pkg.svelte.dev/@sveltejs/kit/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/adapter-vercel/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/enhanced-img/${{ steps.resolve.outputs.ref }} --filter "@sveltejs/docs-types"
 
       - name: Install Svelte CLI upstream
         if: ${{ inputs.upstream == 'cli' }}
-        run: pnpm add -D https://pkg.svelte.dev/sv/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/sv-utils/${{ steps.resolve.outputs.ref }} --filter "svelte.dev"
+        run: pnpm add https://pkg.svelte.dev/sv/${{ steps.resolve.outputs.ref }} https://pkg.svelte.dev/@sveltejs/sv-utils/${{ steps.resolve.outputs.ref }} --filter "@sveltejs/docs-types"
 
       - name: Sync
         run: cd apps/svelte.dev && pnpm sync-docs --owner="${{ inputs.owner }}" -p "${{ format('{0}#{1}#{2}', inputs.upstream, inputs.downstream, inputs.branch) }}"

--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -49,7 +49,7 @@
 		"@resvg/resvg-js": "^2.6.2",
 		"@supabase/supabase-js": "^2.97.0",
 		"@sveltejs/adapter-vercel": "^7.0.0-next.4",
-		"@sveltejs/docs-types": "workspace:*",
+		"docs-types": "workspace:*",
 		"@sveltejs/enhanced-img": "^1.0.0-next.3",
 		"@sveltejs/kit": "catalog:",
 		"@sveltejs/site-kit": "workspace:*",

--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -24,9 +24,6 @@
 		"@lezer/lr": "^1.4.8",
 		"@rich_harris/svelte-split-pane": "^3.0.0",
 		"@sveltejs/repl": "workspace:*",
-		"@testing-library/dom": "^10.4.1",
-		"@testing-library/svelte": "^5.3.1",
-		"@testing-library/user-event": "^14.6.1",
 		"@types/d3-geo": "^3.1.0",
 		"@vercel/analytics": "2.2.0-canary",
 		"@vercel/speed-insights": "2.1.0-canary",
@@ -49,11 +46,9 @@
 		"yootils": "^0.3.1"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20260305.0",
 		"@resvg/resvg-js": "^2.6.2",
 		"@supabase/supabase-js": "^2.97.0",
 		"@sveltejs/adapter-vercel": "^7.0.0-next.4",
-		"@sveltejs/amp": "^1.1.5",
 		"@sveltejs/docs-types": "workspace:*",
 		"@sveltejs/enhanced-img": "^1.0.0-next.3",
 		"@sveltejs/kit": "catalog:",

--- a/apps/svelte.dev/package.json
+++ b/apps/svelte.dev/package.json
@@ -54,6 +54,7 @@
 		"@supabase/supabase-js": "^2.97.0",
 		"@sveltejs/adapter-vercel": "^7.0.0-next.4",
 		"@sveltejs/amp": "^1.1.5",
+		"@sveltejs/docs-types": "workspace:*",
 		"@sveltejs/enhanced-img": "^1.0.0-next.3",
 		"@sveltejs/kit": "catalog:",
 		"@sveltejs/site-kit": "workspace:*",

--- a/apps/svelte.dev/src/lib/server/renderer.ts
+++ b/apps/svelte.dev/src/lib/server/renderer.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const docs_types_root = path.dirname(
-	fileURLToPath(import.meta.resolve('@sveltejs/docs-types/package.json'))
+	fileURLToPath(import.meta.resolve('docs-types/package.json'))
 );
 
 export const render_content = (

--- a/apps/svelte.dev/src/lib/server/renderer.ts
+++ b/apps/svelte.dev/src/lib/server/renderer.ts
@@ -1,11 +1,18 @@
 import { render_content_markdown } from '@sveltejs/site-kit/markdown';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const docs_types_root = path.dirname(require.resolve('@sveltejs/docs-types/package.json'));
 
 export const render_content = (
 	filename: string,
 	body: string,
 	options: { check?: boolean; references?: Record<string, string> } = {}
 ) => {
-	return render_content_markdown(filename, body, options, (filename, source) => {
+	const render_options = { ...options, twoslashRoot: docs_types_root };
+
+	return render_content_markdown(filename, body, render_options, (filename, source) => {
 		// TODO these are copied from Svelte and SvelteKit - adjust for new filenames
 		const injected = [];
 

--- a/apps/svelte.dev/src/lib/server/renderer.ts
+++ b/apps/svelte.dev/src/lib/server/renderer.ts
@@ -2,7 +2,9 @@ import { render_content_markdown } from '@sveltejs/site-kit/markdown';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const docs_types_root = path.dirname(fileURLToPath(import.meta.resolve('@sveltejs/docs-types/package.json')));
+const docs_types_root = path.dirname(
+	fileURLToPath(import.meta.resolve('@sveltejs/docs-types/package.json'))
+);
 
 export const render_content = (
 	filename: string,

--- a/apps/svelte.dev/src/lib/server/renderer.ts
+++ b/apps/svelte.dev/src/lib/server/renderer.ts
@@ -2,9 +2,7 @@ import { render_content_markdown } from '@sveltejs/site-kit/markdown';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const docs_types_root = path.dirname(
-	fileURLToPath(import.meta.resolve('docs-types/package.json'))
-);
+const docs_types_root = path.dirname(fileURLToPath(import.meta.resolve('docs-types/package.json')));
 
 export const render_content = (
 	filename: string,

--- a/apps/svelte.dev/src/lib/server/renderer.ts
+++ b/apps/svelte.dev/src/lib/server/renderer.ts
@@ -1,9 +1,8 @@
 import { render_content_markdown } from '@sveltejs/site-kit/markdown';
 import path from 'node:path';
-import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 
-const require = createRequire(import.meta.url);
-const docs_types_root = path.dirname(require.resolve('@sveltejs/docs-types/package.json'));
+const docs_types_root = path.dirname(fileURLToPath(import.meta.resolve('@sveltejs/docs-types/package.json')));
 
 export const render_content = (
 	filename: string,

--- a/packages/docs-types/package.json
+++ b/packages/docs-types/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@sveltejs/docs-types",
+	"name": "docs-types",
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",

--- a/packages/docs-types/package.json
+++ b/packages/docs-types/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@sveltejs/docs-types",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"dependencies": {
+		"@cloudflare/workers-types": "^4.20260305.0",
+		"@sveltejs/adapter-vercel": "^7.0.0-next.4",
+		"@sveltejs/amp": "^1.1.5",
+		"@sveltejs/enhanced-img": "^1.0.0-next.3",
+		"@sveltejs/kit": "catalog:sveltekit-2",
+		"@sveltejs/sv-utils": "^0.3.2",
+		"@sveltejs/vite-plugin-svelte": "^7.2.0",
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/svelte": "^5.3.1",
+		"@testing-library/user-event": "^14.6.1",
+		"sv": "^0.16.6",
+		"svelte": "^5.56.4",
+		"valibot": "^1.2.0",
+		"vite": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/site-kit/package.json
+++ b/packages/site-kit/package.json
@@ -44,7 +44,8 @@
 		"esm-env": "^1.2.2",
 		"icons": "workspace:*",
 		"json5": "^2.2.3",
-		"shiki": "^4.2.0"
+		"shiki": "^4.2.0",
+		"twoslash": "^0.3.8"
 	},
 	"devDependencies": {
 		"@shikijs/vitepress-twoslash": "^4.2.0",

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -8,7 +8,8 @@ import * as marked from 'marked';
 import { createHighlighterCore } from 'shiki/core';
 import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 import { createCssVariablesTheme } from 'shiki';
-import { transformerTwoslash, rendererRich } from '@shikijs/twoslash';
+import { createTransformerFactory, rendererRich } from '@shikijs/twoslash/core';
+import { createTwoslasher } from 'twoslash';
 // import { createFileSystemTypesCache } from '@shikijs/vitepress-twoslash/cache-fs';
 import { compress_and_encode_text } from 'gzip';
 import {
@@ -327,11 +328,11 @@ function injectReferenceLinks(
 export async function render_content_markdown(
 	filename: string,
 	body: string,
-	options?: { check?: boolean; references?: Record<string, string> },
+	options?: { check?: boolean; references?: Record<string, string>; twoslashRoot?: string },
 	twoslashBanner?: TwoslashBanner
 ) {
 	const headings: string[] = [];
-	const { check = true, references } = options ?? {};
+	const { check = true, references, twoslashRoot } = options ?? {};
 
 	interface CodeBlockFile {
 		selected: boolean;
@@ -504,7 +505,8 @@ export async function render_content_markdown(
 						prelude,
 						source,
 						check,
-						references
+						references,
+						twoslashRoot
 					});
 
 					cached.push(
@@ -524,7 +526,8 @@ export async function render_content_markdown(
 							prelude,
 							source: converted,
 							check,
-							references
+							references,
+							twoslashRoot
 						});
 
 						cached.push(highlighted.replace('<pre', '<pre data-ts'));
@@ -1114,7 +1117,8 @@ async function syntax_highlight({
 	filename,
 	language,
 	check,
-	references
+	references,
+	twoslashRoot
 }: {
 	prelude: string;
 	source: string;
@@ -1122,6 +1126,7 @@ async function syntax_highlight({
 	language: string;
 	check: boolean;
 	references?: Record<string, string>;
+	twoslashRoot?: string;
 }) {
 	let html = '';
 
@@ -1151,7 +1156,10 @@ async function syntax_highlight({
 				theme,
 				transformers: check
 					? [
-							transformerTwoslash({
+							createTransformerFactory(
+								createTwoslasher(twoslashRoot ? { vfsRoot: twoslashRoot } : undefined),
+								rendererRich()
+							)({
 								renderer: rendererRich(),
 								twoslashOptions: {
 									compilerOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,10 @@ catalogs:
     vitest:
       specifier: ^4.1.8
       version: 4.1.8
+  sveltekit-2:
+    '@sveltejs/kit':
+      specifier: ^2.70.2
+      version: 2.70.2
 
 overrides:
   sv>@sveltejs/sv-utils: '-'
@@ -131,6 +135,9 @@ importers:
       '@sveltejs/amp':
         specifier: ^1.1.5
         version: 1.1.5(@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))
+      '@sveltejs/docs-types':
+        specifier: workspace:*
+        version: link:../../packages/docs-types
       '@sveltejs/enhanced-img':
         specifier: ^1.0.0-next.3
         version: 1.0.0-next.3(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(@types/node@22.19.20)(rollup@4.59.0)(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
@@ -206,6 +213,54 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      valibot:
+        specifier: ^1.2.0
+        version: 1.2.0(typescript@6.0.3)
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@22.19.20)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
+
+  packages/docs-types:
+    dependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260305.0
+        version: 4.20260305.0
+      '@sveltejs/adapter-vercel':
+        specifier: ^7.0.0-next.4
+        version: 7.0.0-next.4(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(rollup@4.59.0)
+      '@sveltejs/amp':
+        specifier: ^1.1.5
+        version: 1.1.5(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))
+      '@sveltejs/enhanced-img':
+        specifier: ^1.0.0-next.3
+        version: 1.0.0-next.3(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(@types/node@22.19.20)(rollup@4.59.0)(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
+      '@sveltejs/kit':
+        specifier: catalog:sveltekit-2
+        version: 2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
+      '@sveltejs/sv-utils':
+        specifier: ^0.3.2
+        version: 0.3.2
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.2.0
+        version: 7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))(vitest@4.1.8(@types/node@22.19.20)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      sv:
+        specifier: ^0.16.6
+        version: 0.16.6
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4(@typescript-eslint/types@8.58.0)
       valibot:
         specifier: ^1.2.0
         version: 1.2.0(typescript@6.0.3)
@@ -432,6 +487,9 @@ importers:
       shiki:
         specifier: ^4.2.0
         version: 4.2.0
+      twoslash:
+        specifier: ^0.3.8
+        version: 0.3.8(typescript@6.0.3)
     devDependencies:
       '@shikijs/vitepress-twoslash':
         specifier: ^4.2.0
@@ -1536,6 +1594,22 @@ packages:
       svelte: ^5.0.0
       vite: '>=8.0.12'
 
+  '@sveltejs/kit@2.70.2':
+    resolution: {integrity: sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
+
   '@sveltejs/kit@3.0.0-next.21':
     resolution: {integrity: sha512-+f8Sp5ULdZ5VsNfWHSaX58CoWkXKXrrHJV9xsBI3iWsWHa4Kjyvgjy+Pezf/neWu5elPV9L6k5nR9VtRXHhltQ==}
     engines: {node: '>=22.17'}
@@ -1626,6 +1700,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/d3-geo@3.1.0':
     resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
@@ -1984,6 +2061,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -2716,6 +2797,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   sharp@0.35.3:
     resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
@@ -3728,7 +3812,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       tar: 7.5.22
     transitivePeerDependencies:
       - encoding
@@ -4090,6 +4174,15 @@ snapshots:
     dependencies:
       '@sveltejs/kit': 3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
 
+  '@sveltejs/adapter-vercel@7.0.0-next.4(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(rollup@4.59.0)':
+    dependencies:
+      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vercel/nft': 1.10.2(rollup@4.59.0)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@sveltejs/adapter-vercel@7.0.0-next.4(@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(rollup@4.59.0)':
     dependencies:
       '@sveltejs/kit': 3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
@@ -4098,6 +4191,10 @@ snapshots:
       - encoding
       - rollup
       - supports-color
+
+  '@sveltejs/amp@1.1.5(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
 
   '@sveltejs/amp@1.1.5(@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))':
     dependencies:
@@ -4116,6 +4213,26 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
       - rollup
+
+  '@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.12(acorn@8.18.0)
+      '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.18.0
+      cookie: 0.6.0
+      devalue: 5.9.0
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.2
+      sirv: 3.0.2
+      svelte: 5.56.4(@typescript-eslint/types@8.58.0)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
@@ -4232,6 +4349,8 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/cookie@0.6.0': {}
+
   '@types/d3-geo@3.1.0':
     dependencies:
       '@types/geojson': 7946.0.16
@@ -4296,8 +4415,8 @@ snapshots:
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@rollup/pluginutils': 5.4.0(rollup@4.59.0)
-      acorn: 8.17.0
-      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-import-attributes: 1.9.5(acorn@8.18.0)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -4436,9 +4555,9 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  acorn-import-attributes@1.9.5(acorn@8.17.0):
+  acorn-import-attributes@1.9.5(acorn@8.18.0):
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
   acorn@8.17.0: {}
 
@@ -4554,6 +4673,8 @@ snapshots:
   consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@0.6.0: {}
 
   cookie@1.1.1: {}
 
@@ -5403,6 +5524,8 @@ snapshots:
 
   semver@7.8.5: {}
 
+  set-cookie-parser@3.1.2: {}
+
   sharp@0.35.3(@types/node@22.19.20):
     dependencies:
       '@img/colour': 1.1.0
@@ -5520,14 +5643,14 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
+      '@sveltejs/acorn-typescript': 1.0.12(acorn@8.18.0)
       '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
-      acorn: 8.17.0
+      acorn: 8.18.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.8.1
+      devalue: 5.9.0
       esm-env: 1.2.2
       esrap: 2.2.13(@typescript-eslint/types@8.58.0)
       is-reference: 3.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
       '@sveltejs/adapter-vercel':
         specifier: ^7.0.0-next.4
         version: 7.0.0-next.4(@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(rollup@4.59.0)
-      '@sveltejs/docs-types':
+      'docs-types':
         specifier: workspace:*
         version: link:../../packages/docs-types
       '@sveltejs/enhanced-img':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,15 +50,6 @@ importers:
       '@sveltejs/repl':
         specifier: workspace:*
         version: link:../../packages/repl
-      '@testing-library/dom':
-        specifier: ^10.4.1
-        version: 10.4.1
-      '@testing-library/svelte':
-        specifier: ^5.3.1
-        version: 5.3.1(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))(vitest@4.1.8(@types/node@22.19.20)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))
-      '@testing-library/user-event':
-        specifier: ^14.6.1
-        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/d3-geo':
         specifier: ^3.1.0
         version: 3.1.0
@@ -120,9 +111,6 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1
     devDependencies:
-      '@cloudflare/workers-types':
-        specifier: ^4.20260305.0
-        version: 4.20260305.0
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -132,9 +120,6 @@ importers:
       '@sveltejs/adapter-vercel':
         specifier: ^7.0.0-next.4
         version: 7.0.0-next.4(@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(rollup@4.59.0)
-      '@sveltejs/amp':
-        specifier: ^1.1.5
-        version: 1.1.5(@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))
       '@sveltejs/docs-types':
         specifier: workspace:*
         version: link:../../packages/docs-types
@@ -4195,10 +4180,6 @@ snapshots:
   '@sveltejs/amp@1.1.5(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))':
     dependencies:
       '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
-
-  '@sveltejs/amp@1.1.5(@sveltejs/kit@3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))':
-    dependencies:
-      '@sveltejs/kit': 3.0.0-next.21(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(svelte@5.56.4(@typescript-eslint/types@8.58.0))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))
 
   '@sveltejs/enhanced-img@1.0.0-next.3(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0)))(@types/node@22.19.20)(rollup@4.59.0)(svelte@5.56.4(@typescript-eslint/types@8.58.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
-  - "@sveltejs/*"
+  - '@sveltejs/*'
   - svelte
   - sv
   - esrap
@@ -19,16 +19,20 @@ allowBuilds:
   svelte-preprocess: true
 
 packages:
-  - "apps/*"
-  - "packages/*"
+  - 'apps/*'
+  - 'packages/*'
 
 catalog:
-  "@sveltejs/kit": ^3.0.0-next.21
-  "@types/node": ^22.19.20
+  '@sveltejs/kit': ^3.0.0-next.21
+  '@types/node': ^22.19.20
   vite: ^8.0.16
   vitest: ^4.1.8
+
+catalogs:
+  sveltekit-2:
+    '@sveltejs/kit': ^2.70.2
 
 overrides:
   # This is a workaround to avoid the "exotic dependency is not allowed in subdependencies"
   # error that pnpm throws when `blockExoticSubdeps` is enabled
-  "sv>@sveltejs/sv-utils": "-"
+  'sv>@sveltejs/sv-utils': '-'


### PR DESCRIPTION
This hopefully fixes, once and for all, the issues we have around type mismatches between the version of SvelteKit (and potentially other dependencies) that are used in the site, and the version that the docs refer to.