### PR TITLE
docs: clarify wording in keyed each blocks tutorial

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
@@ -2,7 +2,7 @@
 title: Keyed each blocks
 ---
 
-By default, updating the value of an `each` block will add or remove DOM nodes at the _end_ of the block if the size changes, and update the remaining DOM. That might not be what you want.
+By default, updating the array that an `each` block iterates over will add or remove DOM nodes at the _end_ of the block if the size changes, and update the remaining DOM. That might not be what you want.
 
 It's easier to show why than to explain. Inside `Thing.svelte`, `name` is a dynamic prop but `emoji` is a constant.
 


### PR DESCRIPTION
Fixes #2179

In the keyed each blocks tutorial, the opening sentence says "updating the **value** of an `each` block will add or remove DOM nodes at the end of the block". As reported in #2179, "value" is ambiguous here — a reader can take it to mean some dependent piece of data (the way runes track dependencies) rather than the thing the block iterates over.

This changes the wording to name that thing explicitly:

> By default, updating the array that an `each` block iterates over will add or remove DOM nodes at the _end_ of the block…

One-line change, no behavior or code affected.
