### PR TITLE
fix: exclude embedded skill content from search index on AI docs pages

### DIFF
--- a/apps/svelte.dev/src/routes/content.json/+server.ts
+++ b/apps/svelte.dev/src/routes/content.json/+server.ts
@@ -34,7 +34,13 @@ async function content() {
 		const { slug, body, metadata } = document;
 		const breadcrumbs = document.breadcrumbs.map((x) => clean(x.title));
 
-		const sections = body.trim().split(/^## /m);
+		// skill content embedded in <details> blocks (AI docs) contains its own
+		// headings that don't exist as anchors on the page — exclude from search
+		const searchable_body = slug.startsWith('docs/ai/')
+			? body.replace(/<details>[\s\S]*?<\/details>/g, '')
+			: body;
+
+		const sections = searchable_body.trim().split(/^## /m);
 		const intro = sections?.shift()?.trim()!;
 		const rank = +metadata.rank;
 

--- a/apps/svelte.dev/src/routes/content.json/+server.ts
+++ b/apps/svelte.dev/src/routes/content.json/+server.ts
@@ -37,7 +37,7 @@ async function content() {
 		// skill content embedded in <details> blocks (AI docs) contains its own
 		// headings that don't exist as anchors on the page — exclude from search
 		const searchable_body = slug.startsWith('docs/ai/')
-			? body.replace(/<details>[\s\S]*?<\/details>/g, '')
+			? body.replace(/<details>.*?<\/details>/gs, '')
 			: body;
 
 		const sections = searchable_body.trim().split(/^## /m);


### PR DESCRIPTION
Fixes #2061

This PR strips `<details>...</details>` content from `docs/ai/*` page bodies before splitting them into searchable sections. The skill headings that are real page sections (e.g. `## svelte-code-writer`) remain indexed, since they live outside the `<details>` blocks.