### PR TITLE
fix: deprioritize tutorials and examples in docs search

### DIFF
--- a/apps/svelte.dev/src/routes/content.json/+server.ts
+++ b/apps/svelte.dev/src/routes/content.json/+server.ts
@@ -36,7 +36,7 @@ async function content() {
 
 		const sections = body.trim().split(/^## /m);
 		const intro = sections?.shift()?.trim()!;
-		const rank = +metadata.rank;
+		const rank = +(metadata.rank ?? (slug.startsWith('tutorial/') ? 1 : 0));
 
 		blocks.push({
 			breadcrumbs: [...breadcrumbs, clean(metadata.title ?? '')],

--- a/packages/site-kit/src/lib/search/search.ts
+++ b/packages/site-kit/src/lib/search/search.ts
@@ -50,6 +50,7 @@ const EXACT_MATCH_BOOST = 10;
 const WORD_MATCH_BOOST = 4;
 const NEAR_MATCH_BOOST = 2;
 const BREADCRUMB_LENGTH_BOOST = 0.2;
+const RANK_PENALTY = 1;
 
 interface Entry {
 	block: Block;
@@ -75,10 +76,11 @@ export function search(query: string, path: string): BlockGroup[] {
 		.map((block, rank) => {
 			const block_parts = block.href.split('/');
 
-			// prioritise current section
-			let score = block_parts.findIndex((part, i) => part !== parts[i]);
-			if (score === -1) score = block_parts.length;
-			score *= CURRENT_SECTION_BOOST;
+			// prioritise current section and higher-ranked content
+			let score = -(block.rank ?? 0) * RANK_PENALTY;
+			const matching_parts = block_parts.findIndex((part, i) => part !== parts[i]);
+			score +=
+				(matching_parts === -1 ? block_parts.length : matching_parts) * CURRENT_SECTION_BOOST;
 
 			if (block.breadcrumbs.some((text) => exact_match.test(text))) {
 				console.log('EXACT MATCH', block.breadcrumbs);


### PR DESCRIPTION
Searching for specific API terms can currently put tutorial exercises and examples ahead of the corresponding reference documentation. This assigns tutorials a lower search rank and incorporates content rank into the overall result score so both tutorials and the already rank-10 examples are deprioritized across result groups.

For example, searching `req` now places the `RequestEvent` reference above tutorial results.

Closes #1420
Closes https://github.com/sveltejs/svelte.dev/issues/661