### PR TITLE
fix: include parent titles in search

### DIFF
--- a/packages/site-kit/src/lib/search/search.ts
+++ b/packages/site-kit/src/lib/search/search.ts
@@ -27,7 +27,6 @@ export function init(blocks: Block[]) {
 	indexes = Array.from({ length: max_rank + 1 }, () => new Index({ tokenize: 'forward' }));
 
 	for (const block of blocks) {
-		const title = block.breadcrumbs.at(-1);
 		map.set(block.href, block);
 		// NOTE: we're not using a number as the ID here, but it is recommended:
 		// https://github.com/nextapps-de/flexsearch#use-numeric-ids
@@ -37,7 +36,7 @@ export function init(blocks: Block[]) {
 		// We'd probably want to test both implementations across browsers if memory usage becomes an issue
 		// TODO: fix the type by updating flexsearch after
 		// https://github.com/nextapps-de/flexsearch/pull/364 is merged and released
-		indexes[block.rank ?? 0].add(block.href, `${title} ${block.content}`);
+		indexes[block.rank ?? 0].add(block.href, `${block.breadcrumbs.join(' ')} ${block.content}`);
 
 		hrefs.set(block.breadcrumbs.join('::'), block.href);
 	}
@@ -81,7 +80,6 @@ export function search(query: string, path: string): BlockGroup[] {
 			score *= CURRENT_SECTION_BOOST;
 
 			if (block.breadcrumbs.some((text) => exact_match.test(text))) {
-				console.log('EXACT MATCH', block.breadcrumbs);
 				score += EXACT_MATCH_BOOST;
 			} else if (block.breadcrumbs.some((text) => word_match.test(text))) {
 				score += WORD_MATCH_BOOST;

--- a/packages/site-kit/src/lib/search/search.ts
+++ b/packages/site-kit/src/lib/search/search.ts
@@ -45,9 +45,9 @@ export function init(blocks: Block[]) {
 }
 
 const CURRENT_SECTION_BOOST = 2;
-const EXACT_MATCH_BOOST = 10;
-const WORD_MATCH_BOOST = 4;
-const NEAR_MATCH_BOOST = 2;
+const EXACT_MATCH_BOOST = 100;
+const WORD_MATCH_BOOST = 50;
+const NEAR_MATCH_BOOST = 25;
 const BREADCRUMB_LENGTH_BOOST = 0.2;
 
 interface Entry {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

Tutorial parent titles such as "Advanced loading" were displayed in breadcrumbs but absent from the search index, so searching the exact tutorial title could miss the tutorial entirely.

Index the complete breadcrumb hierarchy alongside body content. The existing breadcrumb scoring boosts then ensure title matches rank above body-only matches. This also removes stray exact-match debug logging.

Closes #1814