### PR TITLE
docs: remove duplicated word in sv utils API page

### DIFF
--- a/apps/svelte.dev/content/docs/cli/50-api/20-sv-utils.md
+++ b/apps/svelte.dev/content/docs/cli/50-api/20-sv-utils.md
@@ -14,7 +14,7 @@ npm install -D @sveltejs/sv-utils
 
 ## transforms
 
-`transforms` is a collection of parser-aware functions that lets you modify the files via abstract syntax tree (AST). It accepts a callback function. The return value is designed to be be passed directly into `sv.file()`. The parser choice is baked into the transform type - you can't accidentally parse a vite config as Svelte because you never call a parser yourself.
+`transforms` is a collection of parser-aware functions that lets you modify the files via abstract syntax tree (AST). It accepts a callback function. The return value is designed to be passed directly into `sv.file()`. The parser choice is baked into the transform type - you can't accidentally parse a vite config as Svelte because you never call a parser yourself.
 
 Each transform injects relevant utilities into the callback, so you only need one import:
 


### PR DESCRIPTION
## Summary

Remove a duplicated word in the CLI `sv` utils API documentation.

| File | Fix |
|------|-----|
| apps/svelte.dev/content/docs/cli/50-api/20-sv-utils.md | "to be be passed" → "to be passed" |

## Test plan

- [x] Verified duplicated word was present before editing
- [x] Residual scan clean on changed file
