### PR TITLE
chore: fix documentation links on preview deployments

### DIFF
--- a/apps/svelte.dev/src/lib/server/renderer.spec.ts
+++ b/apps/svelte.dev/src/lib/server/renderer.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { render_content, replace_canonical_origin } from './renderer.ts';
+
+describe('replace_canonical_origin', () => {
+	test('replaces only the canonical origin and preserves the URL suffix', () => {
+		expect(
+			replace_canonical_origin(
+				'https://svelte.dev/docs/kit?mode=advanced#configuration',
+				'http://localhost:5173'
+			)
+		).toBe('http://localhost:5173/docs/kit?mode=advanced#configuration');
+	});
+
+	test.each([
+		'/docs/kit',
+		'https://example.com/docs/kit',
+		'https://svelte.dev.example.com/docs/kit'
+	])('leaves %s unchanged', (href) => {
+		expect(replace_canonical_origin(href, 'https://preview.example.com')).toBe(href);
+	});
+});
+
+describe('render_content', () => {
+	test('transforms Markdown links when given an origin', async () => {
+		const html = await render_content(
+			'test.md',
+			'[internal](https://svelte.dev/docs/kit) [external](https://example.com/docs)',
+			{ check: false, origin: 'https://preview.example.com' }
+		);
+
+		expect(html).toContain('href="https://preview.example.com/docs/kit"');
+		expect(html).toContain('href="https://example.com/docs"');
+	});
+
+	test('keeps canonical links without an origin', async () => {
+		const html = await render_content('test.md', '[docs](https://svelte.dev/docs/kit)', {
+			check: false
+		});
+
+		expect(html).toContain('href="https://svelte.dev/docs/kit"');
+	});
+});

--- a/apps/svelte.dev/src/lib/server/renderer.ts
+++ b/apps/svelte.dev/src/lib/server/renderer.ts
@@ -3,13 +3,33 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const docs_types_root = path.dirname(fileURLToPath(import.meta.resolve('docs-types/package.json')));
+const canonical_origin = 'https://svelte.dev';
+
+export function replace_canonical_origin(href: string, origin: string) {
+	let url: URL;
+
+	try {
+		url = new URL(href);
+	} catch {
+		return href;
+	}
+
+	return url.origin === canonical_origin
+		? `${origin}${url.pathname}${url.search}${url.hash}`
+		: href;
+}
 
 export const render_content = (
 	filename: string,
 	body: string,
-	options: { check?: boolean; references?: Record<string, string> } = {}
+	options: { check?: boolean; origin?: string; references?: Record<string, string> } = {}
 ) => {
-	const render_options = { ...options, twoslashRoot: docs_types_root };
+	const { origin, ...rest } = options;
+	const render_options = {
+		...rest,
+		transformLink: origin ? (href: string) => replace_canonical_origin(href, origin) : undefined,
+		twoslashRoot: docs_types_root
+	};
 
 	return render_content_markdown(filename, body, render_options, (filename, source) => {
 		// TODO these are copied from Svelte and SvelteKit - adjust for new filenames

--- a/apps/svelte.dev/src/routes/docs/[topic]/[...path=documentation]/+page.server.js
+++ b/apps/svelte.dev/src/routes/docs/[topic]/[...path=documentation]/+page.server.js
@@ -14,7 +14,7 @@ export async function load({ url, params }) {
 	return {
 		document: {
 			...document,
-			body: await render_content(document.file, document.body, { references })
+			body: await render_content(document.file, document.body, { origin: url.origin, references })
 		},
 		related: get_related_links(url.pathname)
 	};

--- a/packages/site-kit/src/lib/markdown/renderer.ts
+++ b/packages/site-kit/src/lib/markdown/renderer.ts
@@ -228,6 +228,7 @@ const snippets = await create_snippet_cache();
  * @param {object} options
  * @param {TwoslashBanner} [options.twoslashBanner] - A function that returns a string to be prepended to the code snippet before running the code with twoslash. Helps in adding imports from svelte or sveltekit or whichever modules are being globally referenced in all or most code snippets.
  * @param {Record<string, string>} [references] - Optional map of symbol names to their documentation URLs for dynamic reference links in twoslash tooltips.
+ * @param {(href: string) => string} [options.transformLink] - Transforms Markdown link destinations before rendering.
  */
 
 /**
@@ -328,11 +329,16 @@ function injectReferenceLinks(
 export async function render_content_markdown(
 	filename: string,
 	body: string,
-	options?: { check?: boolean; references?: Record<string, string>; twoslashRoot?: string },
+	options?: {
+		check?: boolean;
+		references?: Record<string, string>;
+		transformLink?: (href: string) => string;
+		twoslashRoot?: string;
+	},
 	twoslashBanner?: TwoslashBanner
 ) {
 	const headings: string[] = [];
-	const { check = true, references, twoslashRoot } = options ?? {};
+	const { check = true, references, transformLink, twoslashRoot } = options ?? {};
 
 	interface CodeBlockFile {
 		selected: boolean;
@@ -359,6 +365,10 @@ export async function render_content_markdown(
 
 	let transformed = await transform(body, {
 		async walkTokens(token) {
+			if (token.type === 'link' && transformLink) {
+				token.href = transformLink(token.href);
+			}
+
 			if (token.type === 'html') {
 				if (token.text.startsWith('<!-- codeblock:start')) {
 					if (current_block !== null) {


### PR DESCRIPTION
Closes #887

replaces those pesky hardcoded svelte.dev links (used in API JSDocs) with either the localhost origin during dev or the vercel preview URL when building