### PR TITLE
docs: clarify 'each block value' means the iterated array

### DIFF
--- a/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
+++ b/apps/svelte.dev/content/tutorial/01-svelte/04-logic/05-keyed-each-blocks/index.md
@@ -2,7 +2,7 @@
 title: Keyed each blocks
 ---
 
-By default, updating the value of an `each` block will add or remove DOM nodes at the _end_ of the block if the size changes, and update the remaining DOM. That might not be what you want.
+By default, when the array that an `each` block iterates over changes, Svelte adds or removes DOM nodes at the _end_ of the block if the length changes, and updates the remaining DOM nodes in-place. That might not be what you want.
 
 It's easier to show why than to explain. Inside `Thing.svelte`, `name` is a dynamic prop but `emoji` is a constant.
 


### PR DESCRIPTION
Closes #2179

## Summary

The opening sentence of the keyed each blocks tutorial said:

> By default, **updating the value of an `each` block** will add or remove DOM nodes at the _end_ of the block if the size changes, and update the remaining DOM.

"The value of an `each` block" is ambiguous — a reader may reasonably wonder whether "value" means the array being iterated over, a per-item value, or something else. Issue #2179 points out that the phrase caused confusion because it reads as if some reactive derived value is changing, not the iterable array itself.

This PR rephrases the sentence to name the subject explicitly:

> By default, **when the array that an `each` block iterates over changes**, Svelte adds or removes DOM nodes at the _end_ of the block if the length changes, and updates the remaining DOM nodes in-place.

## Test plan

Documentation-only change — no code modified.