### PR TITLE
fix: prevent text overflow on narrow screens

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -128,6 +128,8 @@
 
 <style>
 	.text :global {
+		overflow-wrap: anywhere;
+
 		h2,
 		h3 {
 			max-width: 100%;
@@ -162,6 +164,7 @@
 
 		code:not(pre *),
 		kbd {
+			overflow-wrap: normal;
 			white-space: pre-wrap;
 			padding: 0.2rem 0.4rem;
 			margin: 0 0.2rem;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

Fixes #530

## Problem

On narrow mobile viewports, consecutive inline code elements separated by punctuation could expand the documentation content beyond the viewport.

On the Svelte 5 migration guide, the `clientWidth` / `clientHeight` / `offsetWidth` / `offsetHeight` sequence caused horizontal scrolling. As a result, the bottom previous/next navigation appeared to be hidden outside the viewport.

## Solution

Allow regular content rendered by the shared `Text` component to wrap when necessary, while keeping inline `code` and `kbd` tokens intact.

This lets the browser wrap consecutive inline code elements at their separators instead of breaking identifiers or expanding the page width.

This PR only changes the shared `Text` component styling. It does not modify synced documentation content.

## Validation

At a 320px viewport:

- Before: page `scrollWidth` was 350px
- After: page `scrollWidth` is 320px
- The previous/next controls remain entirely within the viewport
- Inline code identifiers remain intact

Also verified at a 360px viewport.

The following checks pass:

- `pnpm --filter @sveltejs/site-kit lint`
- `pnpm --filter @sveltejs/site-kit check`
- `pnpm --filter svelte.dev check`
- `pnpm build`
