### PR TITLE
fix: shrink file tree code blocks

### DIFF
--- a/packages/site-kit/src/lib/components/Text.svelte
+++ b/packages/site-kit/src/lib/components/Text.svelte
@@ -429,6 +429,18 @@
 					}
 				}
 			}
+
+			@media (min-width: 767px) {
+				&:has(pre[data-language='tree']) {
+					display: table;
+					max-width: 100%;
+
+					pre {
+						width: auto;
+						padding-right: 4rem;
+					}
+				}
+			}
 		}
 
 		p code {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

Fixes #258

## Problem

File tree code blocks in documentation and blog posts currently expand to the full content width, even when the tree itself is much narrower. This leaves a large amount of empty space and makes file trees look disproportionate compared with their content.

## Solution

Shrink `tree` code blocks to their intrinsic content width on non-mobile viewports while keeping them capped at the available content width.

The inner `pre` uses automatic width so it can contribute its intrinsic size, with extra right padding reserved for the copy button. Mobile layouts keep the existing full-width block and horizontal scrolling behavior.

This only targets code blocks whose generated `pre` has `data-language="tree"`; other code blocks are unchanged.

## Validation

Chrome layout measurements:

- Docs project structure page: 749px block reduced to 354px
- Blog file trees: 856px blocks reduced to approximately 245px and 254px
- 320px mobile viewport: block remains 288px wide with internal horizontal scrolling

The following checks pass:

- `pnpm --filter @sveltejs/site-kit lint`
- `pnpm --filter @sveltejs/site-kit check`
- `pnpm --filter svelte.dev check`
- `pnpm build`
