### PR TITLE
fix: banner: corrected summit date (Nov 19-20)

### DIFF
--- a/apps/svelte.dev/src/routes/+layout.server.ts
+++ b/apps/svelte.dev/src/routes/+layout.server.ts
@@ -64,8 +64,8 @@ const banner: BannerData = {
 	end: new Date('20 November, 2026 23:59:59 UTC'),
 	arrow: true,
 	content: {
-		lg: 'Svelte Summit Ljubljana and online, Nov 18-19: Tickets now available!',
-		sm: 'Svelte Summit Nov 18-19'
+		lg: 'Svelte Summit Ljubljana and online, Nov 19-20: Tickets now available!',
+		sm: 'Svelte Summit Nov 19-20'
 	},
 	href: 'https://www.sveltesummit.com/'
 };


### PR DESCRIPTION
Svelte summit is 19-20 November.

"When
November 19-20, 2026" from https://sveltesummit.com/