### PR TITLE
feat: playground local dev without Supabase

### DIFF
--- a/apps/svelte.dev/.gitignore
+++ b/apps/svelte.dev/.gitignore
@@ -16,3 +16,4 @@
 /content/docs/kit/50-reference
 .vercel
 .env*.local
+/tmp/

--- a/apps/svelte.dev/README.md
+++ b/apps/svelte.dev/README.md
@@ -14,6 +14,10 @@ The tutorial, blog and examples are maintained within this repository.
 
 ## Development
 
+### Playground
+
+See [docs/playground.md](docs/playground.md) for how saving apps works and how to run it locally.
+
 ### Tutorial
 
 The tutorial consists of two technically different parts: The Svelte tutorial and the SvelteKit tutorial. The SvelteKit tutorial uses [WebContainers](https://webcontainers.io/) under the hood in order to boot up a Node runtime in the browser. The Svelte tutorial uses Rollup in a web worker - it does not use WebContainers because a simple web worker is both faster and more reliable (there are known issues with iOS mobile).

--- a/apps/svelte.dev/docs/playground.md
+++ b/apps/svelte.dev/docs/playground.md
@@ -1,0 +1,18 @@
+# Playground: saving apps
+
+Logged-in users can save, fork and list apps (`/apps`). Auth is GitHub OAuth; apps and sessions live in Supabase (`gist` table + `login`/`get_user`/`logout`/`gist_*` rpcs).
+
+## Dev
+
+Click "log in" in the playground: without GitHub credentials the popup explains how to register an OAuth app and what to put in `.env.local`.
+
+Without `SUPABASE_URL`/`SUPABASE_KEY`, sessions and apps are stored in `tmp/playground.json` (`src/lib/db/dev.js`) so save/fork/list work locally. Loading an id that isn't there proxies to svelte.dev, so existing playground links still open.
+
+## Prod
+
+```
+GITHUB_CLIENT_ID=...
+GITHUB_CLIENT_SECRET=...
+SUPABASE_URL=...
+SUPABASE_KEY=...
+```

--- a/apps/svelte.dev/src/lib/db/dev.js
+++ b/apps/svelte.dev/src/lib/db/dev.js
@@ -1,0 +1,120 @@
+import { dev } from '$app/env';
+import fs from 'node:fs';
+import path from 'node:path';
+import { client } from './client.js';
+
+// Dev-only stand-in for the Supabase rpcs, so GitHub login and saving work without a database.
+
+/** @typedef {import('./types').GitHubUser} GitHubUser */
+/** @typedef {import('./types').User} User */
+/** @typedef {import('./types').Gist & { userid: number, created_at: string, updated_at: string, deleted_at?: string }} Row */
+
+const FILE = path.resolve('tmp/playground.json');
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export const enabled = dev && !client;
+
+function load() {
+	try {
+		return JSON.parse(fs.readFileSync(FILE, 'utf-8'));
+	} catch {
+		return { users: {}, sessions: {}, gists: {} };
+	}
+}
+
+/** @param {{ users: Record<string, User & { github_id: string }>, sessions: Record<string, { userid: number, expires: number }>, gists: Record<string, Row> }} db */
+function save(db) {
+	fs.mkdirSync(path.dirname(FILE), { recursive: true });
+	fs.writeFileSync(FILE, JSON.stringify(db, null, '\t'));
+}
+
+/** @param {GitHubUser} user */
+export function login(user) {
+	const db = load();
+	let existing = Object.values(db.users).find((u) => u.github_id === user.github_id);
+	if (!existing) {
+		existing = { id: Object.keys(db.users).length + 1, ...user };
+		db.users[existing.id] = existing;
+	} else {
+		Object.assign(existing, user);
+	}
+	const sessionid = crypto.randomUUID();
+	const expires = Date.now() + SESSION_TTL_MS;
+	db.sessions[sessionid] = { userid: existing.id, expires };
+	save(db);
+	return { sessionid, userid: existing.id, expires };
+}
+
+/** @param {string} sessionid */
+export function get_user(sessionid) {
+	const db = load();
+	const s = db.sessions[sessionid];
+	if (!s || s.expires < Date.now()) return null;
+	const { github_id, ...user } = db.users[s.userid];
+	return user;
+}
+
+/** @param {string} sessionid */
+export function logout(sessionid) {
+	const db = load();
+	delete db.sessions[sessionid];
+	save(db);
+}
+
+/** @param {number} userid @param {string} search */
+export function gist_list(userid, search) {
+	const q = search.toLowerCase();
+	return Object.values(load().gists)
+		.filter((g) => g.userid === userid && !g.deleted_at && g.name.toLowerCase().includes(q))
+		.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+}
+
+/** @param {number} userid @param {Pick<Row, 'name'|'files'|'tailwind'>} gist */
+export function gist_create(userid, gist) {
+	const db = load();
+	const now = new Date().toISOString();
+	const row = {
+		id: crypto.randomUUID(),
+		name: gist.name,
+		files: gist.files,
+		tailwind: gist.tailwind ?? false,
+		userid,
+		owner: userid,
+		created_at: now,
+		updated_at: now
+	};
+	db.gists[row.id] = row;
+	save(db);
+	return row;
+}
+
+/** @param {string} id */
+export function gist_read(id) {
+	const g = Object.values(load().gists).find(
+		(g) => g.id.replace(/-/g, '') === id.replace(/-/g, '')
+	);
+	return g && !g.deleted_at ? g : undefined;
+}
+
+/** @param {number} userid @param {string} id @param {Pick<Row, 'name'|'files'|'tailwind'>} gist */
+export function gist_update(userid, id, gist) {
+	const db = load();
+	const row = Object.values(db.gists).find((g) => g.id.replace(/-/g, '') === id.replace(/-/g, ''));
+	if (!row || row.userid !== userid) throw new Error('not found');
+	Object.assign(row, { name: gist.name, files: gist.files, tailwind: gist.tailwind ?? false });
+	row.updated_at = new Date().toISOString();
+	save(db);
+	return row;
+}
+
+/** @param {number} userid @param {string[]} ids */
+export function gist_destroy(userid, ids) {
+	const db = load();
+	const wanted = new Set(ids.map((id) => id.replace(/-/g, '')));
+	for (const row of Object.values(db.gists)) {
+		if (row.userid === userid && wanted.has(row.id.replace(/-/g, ''))) {
+			row.deleted_at = new Date().toISOString();
+		}
+	}
+	save(db);
+}

--- a/apps/svelte.dev/src/lib/db/gist.js
+++ b/apps/svelte.dev/src/lib/db/gist.js
@@ -1,4 +1,5 @@
 import { client } from './client.js';
+import * as local from './dev.js';
 
 /** @typedef {import('./types').User} User */
 /** @typedef {import('./types').UserID} UserID */
@@ -14,6 +15,11 @@ const PAGE_SIZE = 90;
  * }} opts
  */
 export async function list(user, { offset, search }) {
+	if (local.enabled) {
+		const gists = local.gist_list(user.id, search || '');
+		return { gists: gists.slice(offset, offset + PAGE_SIZE), next: null };
+	}
+
 	const { data, error } = await client.rpc('gist_list', {
 		list_search: search || '',
 		list_userid: user.id,
@@ -42,6 +48,8 @@ export async function list(user, { offset, search }) {
  * @returns {Promise<Gist>}
  */
 export async function create(user, gist) {
+	if (local.enabled) return local.gist_create(user.id, gist);
+
 	const { data, error } = await client.rpc('gist_create', {
 		name: gist.name,
 		files: gist.files,
@@ -61,6 +69,8 @@ export async function create(user, gist) {
  * @returns {Promise<Partial<Gist>>}
  */
 export async function read(id) {
+	if (local.enabled) return local.gist_read(id);
+
 	const { data, error } = await client
 		.from('gist')
 		.select('id,name,files,tailwind,userid')
@@ -78,6 +88,8 @@ export async function read(id) {
  * @returns {Promise<Gist>}
  */
 export async function update(user, gistid, gist) {
+	if (local.enabled) return local.gist_update(user.id, gistid, gist);
+
 	const { data, error } = await client.rpc('gist_update', {
 		gist_id: gistid,
 		gist_name: gist.name,
@@ -98,6 +110,8 @@ export async function update(user, gistid, gist) {
  * @param {string[]} ids
  */
 export async function destroy(userid, ids) {
+	if (local.enabled) return local.gist_destroy(userid, ids);
+
 	const { error } = await client.rpc('gist_destroy', {
 		gist_ids: ids,
 		gist_userid: userid

--- a/apps/svelte.dev/src/lib/db/session.js
+++ b/apps/svelte.dev/src/lib/db/session.js
@@ -1,6 +1,7 @@
 import * as cookie from 'cookie';
 import flru from 'flru';
 import { client } from './client.js';
+import * as local from './dev.js';
 import { error } from '@sveltejs/kit';
 
 /** @typedef {import('./types').User} User */
@@ -14,6 +15,12 @@ const session_cache = flru(1000);
  * @param {import('./types').GitHubUser} user
  */
 export async function create(user) {
+	if (local.enabled) {
+		const { sessionid, userid, expires } = local.login(user);
+		session_cache.set(sessionid, { id: userid, ...user });
+		return { sessionid, expires: new Date(expires) };
+	}
+
 	if (!client) {
 		error(500, 'Database client is not configured');
 	}
@@ -47,7 +54,9 @@ export async function create(user) {
  * @returns {Promise<User | null>}
  */
 export async function read(sessionid) {
-	if (!sessionid || !client) return null;
+	if (!sessionid) return null;
+	if (local.enabled) return local.get_user(sessionid);
+	if (!client) return null;
 
 	if (!session_cache.get(sessionid)) {
 		session_cache.set(
@@ -68,6 +77,12 @@ export async function read(sessionid) {
 
 /** @param {string} sessionid */
 export async function destroy(sessionid) {
+	if (local.enabled) {
+		local.logout(sessionid);
+		session_cache.set(sessionid, null);
+		return;
+	}
+
 	if (!client) {
 		error(500, 'Database client is not configured');
 	}

--- a/apps/svelte.dev/src/routes/(authed)/+layout.svelte
+++ b/apps/svelte.dev/src/routes/(authed)/+layout.svelte
@@ -12,7 +12,7 @@
 				if (event.key === storage_key) {
 					invalidateAll();
 					window.removeEventListener('storage', handler);
-					this.localStorage.clearItem(storage_key);
+					this.localStorage.removeItem(storage_key);
 				}
 			});
 		},

--- a/apps/svelte.dev/src/routes/(authed)/playground/api/[id].json/+server.ts
+++ b/apps/svelte.dev/src/routes/(authed)/playground/api/[id].json/+server.ts
@@ -26,7 +26,7 @@ export async function GET({ fetch, params }) {
 		});
 	}
 
-	if (dev && !client) {
+	if (dev && !client && !(await gist.read(params.id))) {
 		// in dev with no local Supabase configured, proxy to production
 		// this lets us at least load saved REPLs
 		const res = await fetch(`https://svelte.dev/playground/api/${params.id}.json`);


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.

---

Today, without `SUPABASE_URL`/`SUPABASE_KEY`, logging in to the playground 500s and nothing can be saved locally. This adds a dev-only fallback (`src/lib/db/dev.js`) that keeps GitHub sessions and apps in `tmp/playground.json`, so save/fork/list work out of the box. Unknown ids still proxy to svelte.dev as before.

Also fixes `localStorage.clearItem` (not a function) in the login side-channel, and starts `docs/playground.md`.